### PR TITLE
doc: Add Bluetooth trademark

### DIFF
--- a/docs/ble/index.rst
+++ b/docs/ble/index.rst
@@ -7,8 +7,8 @@ BLE Network Overview
 Introduction
 ************
 
-The Hubble BLE Network is a framework designed to provide secure and
-efficient communication within a Bluetooth Low Energy (BLE) environment.
+The Hubble Bluetooth® Low Energy (BLE) Network is a framework designed to provide secure
+and efficient communication within a Bluetooth Low Energy (BLE) environment.
 Advanced encryption techniques and Bluetooth technology protect data
 integrity and privacy across distributed systems. The Hubble BLE API, defined
 in the **hubble_ble.h** header file, provides a comprehensive set of functions

--- a/docs/ble/security.rst
+++ b/docs/ble/security.rst
@@ -3,8 +3,8 @@
 BLE  Security Overview
 ######################
 
-The cryptographic techniques used in the Hubble BLE Network ensure the
-confidentiality, integrity, and authenticity of the data being advertised
+The cryptographic techniques used in the Hubble Bluetooth® Low Energy (BLE) Network ensure
+the confidentiality, integrity, and authenticity of the data being advertised
 over BLE. AES-256 provides strong encryption, CMAC ensures data integrity and
 authenticity, and the KBKDF securely derives keys from a master key. The use
 of nonces and sequence numbers prevents replay attacks and ensures that each
@@ -26,7 +26,7 @@ Key concepts
   provided key, and the result is stored in the output buffer.
 
 .. _hubble_ble_kbdf:
- 
+
 * **KBKDF (Key-Based Key Derivation Function)**
 
   The code uses a KBKDF to derive keys from a master key. It derives keys

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -46,10 +46,18 @@ target radio and possibly other devices when in use.
 BLE Network Module
 ------------------
 
-Offers APIs to generate Bluetooth advertisement packets, enabling connections
-to the Hubble BLE Network. This module uses the standard Bluetooth protocol
+Offers APIs to generate Bluetooth® advertisement packets, enabling connections
+to the Hubble Bluetooth Low Energy (BLE) Network. This module uses the standard Bluetooth protocol
 and does not assume ownership of any hardware. The application is responsible
 for managing the Bluetooth stack.
+
+Bluetooth Member Details
+------------------------
+Hubble Network Inc. is a Bluetooth Member Company.
+The Hubble Network SDK has completed the Bluetooth Qualification Process:
+
+- Hubble Design Number: Q369913
+- Qualified Product Details: https://qualification.bluetooth.com/ListingDetails/307489
 
 Port Layer
 ==========

--- a/docs/quickstart/zephyr/index.rst
+++ b/docs/quickstart/zephyr/index.rst
@@ -49,8 +49,8 @@ To enable the required modules, add the corresponding lines to the project’s
     CONFIG_HUBBLE_BLE_NETWORK=y
     CONFIG_HUBBLE_SAT_NETWORK=y
 
-Use ``CONFIG_HUBBLE_BLE_NETWORK=y`` to enable the BLE network module or
-``CONFIG_HUBBLE_SAT_NETWORK=y`` for the satellite network module.
+Use ``CONFIG_HUBBLE_BLE_NETWORK=y`` to enable the Bluetooth® Low Energy (BLE) Network module or
+``CONFIG_HUBBLE_SAT_NETWORK=y`` for the Satellite Network module.
 
 Using Hubble Network as the manifest repository
 ***********************************************
@@ -118,7 +118,7 @@ Building and running your first application
 
 Building and Running the First Application Once the steps in the previous
 section are complete, the system is ready to use Hubble Network. The following
-commands demonstrate how to build and flash a BLE network application.
+commands demonstrate how to build and flash a BLE Network application.
 
 Build the application
 ---------------------


### PR DESCRIPTION
Update documentation adding Bluetooth Member Detail and Qualified Product Design Number for Hubble Network SDK. Additional updates made to docs in order to adhere to Bluetooth brand guidance.