### PR TITLE
samples: zephyr/blue-beacon: CTS time sync

### DIFF
--- a/samples/zephyr/ble-beacon/Kconfig
+++ b/samples/zephyr/ble-beacon/Kconfig
@@ -29,6 +29,14 @@ config HUBBLE_BEACON_SAMPLE_ADDITIONAL_ADV_DATA
 	Data to be advertised
 endif
 
+config HUBBLE_BEACON_SAMPLE_USE_CTS
+    bool "Use CTS to sync UTC time"
+    default n
+    select BT_CTS
+    select BT_CTS_HELPER_API
+    help
+       Use CTS to sync time instead of hardcode during building.
+
 config HUBBLE_BEACON_SAMPLE_UPDATE_ADDRESS
     bool "Generate new address periodically"
     default y

--- a/samples/zephyr/ble-beacon/Kconfig
+++ b/samples/zephyr/ble-beacon/Kconfig
@@ -37,22 +37,11 @@ config HUBBLE_BEACON_SAMPLE_USE_CTS
     help
        Use CTS to sync time instead of hardcode during building.
 
-config HUBBLE_BEACON_SAMPLE_UPDATE_ADDRESS
-    bool "Generate new address periodically"
-    default y
+config HUBBLE_BEACON_SAMPLE_UPDATE_ADV_PERIOD
+    int "Period to update the advertisment packet"
+    default 360
     help
-	Generate a new a Non-Resolvable Private Address
-	periodically.
-
-if HUBBLE_BEACON_SAMPLE_UPDATE_ADDRESS
-
-config HUBBLE_BEACON_SAMPLE_UPDATE_ADDRESS_PERIOD
-    int "Period to update the address"
-    default 120
-    help
-	Period (in seconds) to generate a new a Non-Resolvable Private Address
-	periodically.
-endif
+	Period (in seconds) to generate a new advertisement message.
 
 endmenu
 

--- a/samples/zephyr/ble-beacon/README.md
+++ b/samples/zephyr/ble-beacon/README.md
@@ -23,6 +23,16 @@ The provisioning process embeds a master key and the current UTC time into the
 firmware. This is a necessary step before building and flashing the
 application.
 
+> [!TIP]
+> The application can be configured to sync time at runtime using *Current time Service (CTS)*,
+> this option is recommended for long running tests because it is possible sync time after
+> reboots without changing the firmware. To enable this option add the following option
+> in `prj.conf`
+>
+> ```
+> CONFIG_HUBBLE_BEACON_SAMPLE_USE_CTS=y
+> ```
+
 ### 2. Run the Provisioning Script
 
 The `embed_key_utc.py` script takes the key file and embeds it along with the
@@ -54,6 +64,14 @@ west flash
 ```
 
 After flashing, the device will start advertising as a Hubble BLE beacon.
+
+> [!WARNING]
+> If the application was built with `CONFIG_HUBBLE_BEACON_SAMPLE_USE_CTS` enabled, it is necessary
+> to sync utc time. This can be done using the `sync_time.py` script:
+>
+> ```sh
+> ./sync_time.py
+> ```
 
 ## Configuration
 

--- a/samples/zephyr/ble-beacon/src/main.c
+++ b/samples/zephyr/ble-beacon/src/main.c
@@ -7,6 +7,10 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#ifdef CONFIG_HUBBLE_BEACON_SAMPLE_USE_CTS
+#include <zephyr/bluetooth/services/cts.h>
+#include <zephyr/bluetooth/conn.h>
+#endif /* CONFIG_HUBBLE_BEACON_SAMPLE_USE_CTS */
 #include <zephyr/logging/log.h>
 
 #include <stdint.h>
@@ -50,6 +54,92 @@ K_TIMER_DEFINE(mac_timer, timer_cb, NULL);
 #endif /* CONFIG_HUBBLE_BEACON_SAMPLE_UPDATE_ADDRESS */
 
 
+#ifdef CONFIG_HUBBLE_BEACON_SAMPLE_USE_CTS
+
+/* Lets use 0xFCA7 UUID for when it is connectable. Since this UUID is also
+ * assigned to Hubble. This way it is easy to distinguish between a device
+ * that is properly beaconing from one that needs time synchronization.
+ */
+#define HUBBLE_BLE_UUID_SYNC 0xFCA7
+
+static int ble_adv_time_sync(void)
+{
+	int err;
+
+	*(uint16_t *)&app_adv_uuids = HUBBLE_BLE_UUID_SYNC;
+
+	app_ad[1].data_len = sizeof(uint16_t);
+	app_ad[1].type = BT_DATA_SVC_DATA16;
+	app_ad[1].data = (uint8_t *)&app_adv_uuids;
+
+	err = bt_le_adv_start(BT_LE_ADV_PARAM(BT_LE_ADV_OPT_USE_NRPA | BT_LE_ADV_OPT_CONN,
+					      BT_GAP_ADV_FAST_INT_MIN_2,
+					      BT_GAP_ADV_FAST_INT_MAX_2, NULL),
+			      app_ad, ARRAY_SIZE(app_ad), NULL, 0);
+
+	return err;
+}
+
+static void ble_work_handler(struct k_work *work)
+{
+	ble_adv_time_sync();
+}
+
+K_WORK_DEFINE(ble_work, ble_work_handler);
+K_SEM_DEFINE(time_sem, 0, 1);
+
+static int bt_cts_cts_time_write(struct bt_cts_time_format *cts_time)
+{
+	return bt_cts_time_to_unix_ms(cts_time, &utc_time);
+}
+
+int bt_cts_fill_current_cts_time(struct bt_cts_time_format *cts_time)
+{
+	return bt_cts_time_from_unix_ms(cts_time, utc_time + k_uptime_get());
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	if (utc_time != 0) {
+		k_sem_give(&time_sem);
+	} else {
+		k_work_submit(&ble_work);
+	}
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.disconnected = disconnected,
+};
+
+const struct bt_cts_cb cts_cb = {
+	.cts_time_write = bt_cts_cts_time_write,
+	.fill_current_cts_time = bt_cts_fill_current_cts_time,
+};
+
+static int hubble_ble_time_sync(void)
+{
+	int ret = 0;
+
+	/* Lets ensure that utc_time is not set */
+	utc_time = 0;
+
+	bt_cts_init(&cts_cb);
+
+	ret = ble_adv_time_sync();
+	if (ret != 0) {
+		return ret;
+	}
+
+	k_sem_take(&time_sem, K_FOREVER);
+
+	/* Get back to 0xFCA6 for future regular advertisements */
+	*(uint16_t *)&app_adv_uuids = HUBBLE_BLE_UUID;
+
+	return ret;
+}
+
+#endif /* CONFIG_HUBBLE_BEACON_SAMPLE_USE_CTS */
+
 int main(void)
 {
 	void *data;
@@ -58,18 +148,6 @@ int main(void)
 
 	LOG_DBG("Hubble Network BLE Beacon started");
 
-	err = hubble_ble_init(utc_time);
-	if (err != 0) {
-		LOG_ERR("Failed to initialize Hubble BLE Network");
-		return err;
-	}
-
-	err = hubble_ble_key_set(master_key);
-	if (err != 0) {
-		LOG_ERR("Failed to set the Hubble key");
-		return err;
-	}
-
 	/* Synchrounosly initialize the Bluetooth subsystem. */
 	err = bt_enable(NULL);
 	if (err != 0) {
@@ -77,10 +155,30 @@ int main(void)
 		return err;
 	}
 
+#ifdef CONFIG_HUBBLE_BEACON_SAMPLE_USE_CTS
+	err = hubble_ble_time_sync();
+	if (err != 0) {
+		LOG_ERR("Could not get utc time synced !");
+		goto end;
+	}
+#endif /* CONFIG_HUBBLE_BEACON_SAMPLE_USE_CTS */
+
+	err = hubble_ble_init(utc_time);
+	if (err != 0) {
+		LOG_ERR("Failed to initialize Hubble BLE Network");
+		goto end;
+	}
+
+	err = hubble_ble_key_set(master_key);
+	if (err != 0) {
+		LOG_ERR("Failed to set the Hubble key");
+		goto end;
+	}
+
 	data = hubble_ble_advertise_get(NULL, 0, &out_len);
 	if (data == NULL) {
 		LOG_ERR("Failed to get the advertisement data");
-		return -1;
+		goto end;
 	}
 	app_ad[1].data_len = out_len;
 	app_ad[1].type = BT_DATA_SVC_DATA16;
@@ -134,8 +232,6 @@ int main(void)
 		}
 	}
 #endif /* CONFIG_HUBBLE_BEACON_SAMPLE_UPDATE_ADDRESS */
-
-	return 0;
 
 end:
 	(void)bt_disable();

--- a/samples/zephyr/ble-beacon/sync_time.py
+++ b/samples/zephyr/ble-beacon/sync_time.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Hubble Network, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import datetime
+import os
+import signal
+import struct
+import sys
+import time
+
+
+from bleak import BleakClient, BleakScanner
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
+
+CTS_SERVICE_UUID        =         "00001805-0000-1000-8000-00805f9b34fb"
+CTS_CHARACTERISTIC_UUID =         "00002a2b-0000-1000-8000-00805f9b34fb"
+HUBBLE_BLE_UUID_SYNC    =         "0000fca7"
+
+
+def cts_time_get() -> bytes:
+    now = datetime.datetime.now()
+
+    year = now.year
+    month = now.month
+    day = now.day
+    hour = now.hour
+    minute = now.minute
+    second = now.second
+    day_of_week = (now.isoweekday())  # Monday=1 … Sunday=7
+    fractions256 = int(now.microsecond / 1_000_000 * 256)
+    adjust_reason = 0  # No adjustment
+
+    # Pack into little-endian structure
+    cts_payload = struct.pack(
+        "<HBBBBBB2B",
+        year, month, day, hour, minute, second,
+        day_of_week, fractions256, adjust_reason
+    )
+
+    return cts_payload
+
+
+async def scan(stop_event: asyncio.Event) -> None:
+    def match_hubble_sync_uuid(device: BLEDevice, adv: AdvertisementData):
+        for uuid in adv.service_uuids:
+            if uuid.startswith(HUBBLE_BLE_UUID_SYNC):
+                return True
+
+        return False
+
+    device = await BleakScanner.find_device_by_filter(match_hubble_sync_uuid)
+    if device is not None:
+        async with BleakClient(device) as client:
+            data = bytearray(cts_time_get())
+            print(f"Setting time to: {datetime.datetime.now().isoformat()}")
+            await client.write_gatt_char(CTS_CHARACTERISTIC_UUID, data, response=True)
+    else:
+        print("No device found")
+
+
+def main() -> None:
+    stop_event = asyncio.Event()
+    signal.signal(signal.SIGINT, lambda _, __: stop_event.set())
+
+    asyncio.run(scan(stop_event))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Few improvements in this pr:

- Advertisement updates are now mandatory and run continuously with a configurable period
- Add a build option to CTS interface for time synchronization
  - Documentation updated
  - A new script to sync time using this interface