### PR TITLE
crypto: derive MbedTLS cipher type from CONFIG_HUBBLE_KEY_SIZE

### DIFF
--- a/src/crypto/mbedtls.c
+++ b/src/crypto/mbedtls.c
@@ -12,12 +12,12 @@
 
 #define _STREAM_BLOCK_LEN 16
 
-#if defined(CONFIG_HUBBLE_NETWORK_KEY_256)
+#if CONFIG_HUBBLE_KEY_SIZE == 32
 #define CIPHER_TYPE MBEDTLS_CIPHER_AES_256_ECB
-#elif defined(CONFIG_HUBBLE_NETWORK_KEY_128)
+#elif CONFIG_HUBBLE_KEY_SIZE == 16
 #define CIPHER_TYPE MBEDTLS_CIPHER_AES_128_ECB
 #else
-#error "Invalid Hubble Key size"
+#error "CONFIG_HUBBLE_KEY_SIZE must be 16 or 32"
 #endif
 
 int hubble_crypto_cmac(const uint8_t key[CONFIG_HUBBLE_KEY_SIZE],


### PR DESCRIPTION
The MbedTLS backend selected its AES cipher type using Kconfig boolean macros (CONFIG_HUBBLE_NETWORK_KEY_256 / CONFIG_HUBBLE_NETWORK_KEY_128). These macros are only defined by Zephyr and ESP-IDF Kconfig — the FreeRTOS port configures key size solely through the integer CONFIG_HUBBLE_KEY_SIZE, so building FreeRTOS with the MbedTLS backend would fail at compile time with "Invalid Hubble Key size".

Derive CIPHER_TYPE from CONFIG_HUBBLE_KEY_SIZE instead, matching how the PSA backend already works. The Kconfig boolean choice symbols remain unchanged — they continue to derive the integer in Zephyr and ESP-IDF builds as before.