### PR TITLE
github: publish per-branch docs to gh-pages subdirectories

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,6 +1,10 @@
 name: Build Documentation
 
 on:
+  push:
+    branches:
+      - main
+      - 'release/*'
   pull_request:
     branches: ["**"]
     paths:
@@ -9,14 +13,11 @@ on:
 
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: "Optional PR number to run against (use this to target a PR head)"
-        required: false
-      commit_sha:
-        description: "Optional commit SHA to checkout (overrides pr_number if provided)"
-        required: false
       ref:
-        description: "Optional branch or tag to checkout (used when not supplying pr_number or commit_sha)"
+        description: >
+          Git ref to build docs for. Accepts a branch (main), tag (v1.0),
+          commit SHA, or PR ref (refs/pull/42/head). Defaults to the
+          repository's default branch.
         required: false
 
 permissions:
@@ -25,39 +26,48 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-
+    outputs:
+      slug: ${{ steps.slug.outputs.slug }}
     steps:
       - name: Determine checkout ref
         id: setref
+        env:
+          # workflow_dispatch: use the user-supplied ref; otherwise build
+          # the PR merge ref for pull_request events or fall back to the
+          # branch/tag that triggered the push.
+          INPUT_REF: ${{ inputs.ref }}
+          EVENT_REF: ${{ github.event.pull_request.number && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
         run: |
-          # Determine which ref we should checkout for the build
-          # Priority:
-          # 1. explicit commit_sha input
-          # 2. explicit pr_number input -> refs/pull/<pr>/head
-          # 3. if triggered by a pull_request event -> refs/pull/<pr>/head
-          # 4. explicit ref input
-          # 5. default github.ref
-          echo "event_name=${GITHUB_EVENT_NAME}"
-          if [ -n "${{ github.event.inputs.commit_sha }}" ]; then
-            echo "ref=${{ github.event.inputs.commit_sha }}" >> $GITHUB_OUTPUT
-          elif [ -n "${{ github.event.inputs.pr_number }}" ]; then
-            echo "ref=refs/pull/${{ github.event.inputs.pr_number }}/head" >> $GITHUB_OUTPUT
-          elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            # use the PR head ref for pull_request events
-            echo "ref=refs/pull/${{ github.event.pull_request.number }}/head" >> $GITHUB_OUTPUT
-          elif [ -n "${{ github.event.inputs.ref }}" ]; then
-            echo "ref=${{ github.event.inputs.ref }}" >> $GITHUB_OUTPUT
-          else
-            echo "ref=${GITHUB_REF}" >> $GITHUB_OUTPUT
-          fi
+          REF="${INPUT_REF:-${EVENT_REF}}"
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+
+          # Strip the refs/ prefix so the slug step produces clean
+          # directory names (e.g. "main" instead of "refs-heads-main").
+          case "${REF}" in
+            refs/pull/*/head)
+              echo "ref_name=pr-${REF#refs/pull/}" | sed 's|/head||' >> "$GITHUB_OUTPUT" ;;
+            refs/heads/*)
+              echo "ref_name=${REF#refs/heads/}" >> "$GITHUB_OUTPUT" ;;
+            refs/tags/*)
+              echo "ref_name=${REF#refs/tags/}" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "ref_name=${REF}" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.setref.outputs.ref }}
-          fetch-depth: 0
+          fetch-depth: 1
+
+      - name: Compute branch slug
+        id: slug
+        env:
+          REF_NAME: ${{ steps.setref.outputs.ref_name }}
+        run: |
+          SLUG="${REF_NAME//\//-}"
+          echo "slug=${SLUG}" >> $GITHUB_OUTPUT
+          echo "Branch slug: ${SLUG}"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -72,8 +82,50 @@ jobs:
           pip install -r docs/requirements.txt
 
       - name: Generate documentation
+        env:
+          DOCS_BRANCH: ${{ steps.setref.outputs.ref_name }}
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          SPHINX_BASEURL: "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ steps.slug.outputs.slug }}/"
         run: |
           set -euxo pipefail
           cd docs
           make doxygen
           make html
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-${{ steps.slug.outputs.slug }}
+          path: docs/_build/html
+          retention-days: 1
+
+  deploy:
+    if: |
+      github.event_name == 'push' &&
+      (
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/release/')
+      )
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
+
+    steps:
+      - name: Download docs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-${{ needs.build.outputs.slug }}
+          path: docs-output
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs-output
+          destination_dir: ${{ needs.build.outputs.slug }}
+          keep_files: true
+          commit_message: "Deploy docs for ${{ needs.build.outputs.slug }}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,16 @@ html_theme_options = {
     'navigation_depth': 3,
     }
 
+# -- Multi-version support ---------------------------------------------------
+# DOCS_BRANCH and GITHUB_REPOSITORY_NAME are set by CI.
+_docs_branch = os.environ.get("DOCS_BRANCH", "")
+_repo_name = os.environ.get("GITHUB_REPOSITORY_NAME", "")
+
+html_context = {
+    "is_release": _docs_branch.startswith("release"),
+    "docs_base_path": f"/{_repo_name}/" if _repo_name else "/",
+}
+
 def setup(app):
     # theme customizations
     app.add_css_file("css/custom.css")

--- a/docs/templates/layout.html
+++ b/docs/templates/layout.html
@@ -2,7 +2,7 @@
 {% block document %}
   {% if is_release %}
     <div class="wy-alert wy-alert-danger" data-nosnippet>
-      The <a href="/latest/{{ pagename }}.html">latest development version</a>
+      The <a href="{{ docs_base_path }}main/{{ pagename }}.html">latest development version</a>
       of this page may be more current than this released {{ version }} version.
     </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- Cherry-pick of #160 onto `release/1.0-branch` to enable docs deployment for this branch
- Replaces manual gh-pages deploy logic with `peaceiris/actions-gh-pages@v4`
- Adds `push` trigger for `main` and `release/*` branches
- Deploys docs to a per-branch subdirectory (e.g. `release-1.0-branch/`) on gh-pages

## Test plan
- [ ] Merge and verify the workflow runs and deploys to `release-1.0-branch/` on gh-pages
- [ ] Verify existing `main/` docs are preserved (`keep_files: true`)