### PR TITLE
docs: sat: clarify pass prediction input parameter

### DIFF
--- a/include/hubble/sat/ephemeris.h
+++ b/include/hubble/sat/ephemeris.h
@@ -130,7 +130,7 @@ int hubble_sat_satellites_set(
  * given location, based on satellites orbital parameters
  * and the device's location.
  *
- * @param t Current time or the time from which to start the calculation.
+ * @param t Current time or the time to start the calculation (seconds since Unix epoch).
  * @param pos Pointer to the device's location.
  * @param pass The next satellite pass in case of success.
  * @return 0 on success or a negative value in case of error.
@@ -145,7 +145,7 @@ int hubble_next_pass_get(uint64_t t, const struct hubble_sat_device_pos *pos,
  * rectangular geographic region defined by latitude and longitude
  * bounds, based on satellites orbital parameters.
  *
- * @param t Current time or the time from which to start the calculation.
+ * @param t Current time or the time to start the calculation (seconds since Unix epoch).
  * @param region Pointer to the geographic region definition.
  * @param pass The next satellite pass in case of success.
  * @return 0 on success or a negative value in case of error.


### PR DESCRIPTION
I spent way too long on this until I realize that the input for pass prediction is in seconds, not milliseconds 🫠 
So update the doc to clarify this since it is convenient to call `hubble_time_get` and then forgot to `/ 1000` before input to this function.