### PR TITLE
FreeRTOS - Assorted fixes

### DIFF
--- a/port/freertos/config.h
+++ b/port/freertos/config.h
@@ -14,9 +14,11 @@
 #define CONFIG_HUBBLE_BLE_NETWORK 1
 #endif
 
-#ifndef CONFIG_HUBBLE_SAT_NETWORK
-#define CONFIG_HUBBLE_SAT_NETWORK 0
-#endif
+
+/*
+ * Enable the Hubble Satellite network module.
+ */
+/* #define CONFIG_HUBBLE_SAT_NETWORK 1 */
 
 /*
  * Size of the encryption key in bytes. Valid options are

--- a/samples/freertos/ti/ble-beacon/makefile
+++ b/samples/freertos/ti/ble-beacon/makefile
@@ -43,7 +43,6 @@ OBJECTS = $(addprefix $(BUILD_DIR)/, \
 	  common_iCall_icall_POSIX.obj \
 	  common_config_ble_user_config.obj \
 	  common_Profiles_simple_gatt_simple_gatt_profile.obj \
-	  common_BLE_SysStat_blesysstat.obj \
 	  $(patsubst %.c,%.obj,$(notdir $(SYSCFG_C_FILES))))
 
 
@@ -160,11 +159,6 @@ $(BUILD_DIR)/app_hubble_ble_ti.obj: src/hubble_ble_ti.c $(BUILD_DIR)
 $(BUILD_DIR)/app_main.obj: src/main.c $(SYSCFG_H_FILES) $(BUILD_DIR)
 	@ echo Building $@
 	$(V) $(CC) $(CFLAGS) $(HUBBLENETWORK_SDK_FLAGS) -c $< -o $@
-
-
-$(BUILD_DIR)/common_BLE_SysStat_blesysstat.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/stack_util/health_toolkit/src/ble_sys_stat.c $(SYSCFG_H_FILES) $(BUILD_DIR)
-	@ echo Building $@
-	$(V) $(CC) $(CFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/common_Services_dev_info_dev_info_service.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/services/dev_info/src/dev_info_service.c $(SYSCFG_H_FILES) $(BUILD_DIR)
 	@ echo Building $@

--- a/samples/freertos/ti/ble-beacon/src/hubble_ble_adv.c
+++ b/samples/freertos/ti/ble-beacon/src/hubble_ble_adv.c
@@ -16,10 +16,10 @@
 #define HUBBLE_BLE_ADV_HEADER                                                  \
 	0x03, GAP_ADTYPE_16BIT_COMPLETE, LO_UINT16(0xfca6), HI_UINT16(0xfca6), \
 		0x01, GAP_ADTYPE_SERVICE_DATA,
-#define HUBBLE_BLE_ADV_HEADER_SIZE 6
+#define BLE_ADV_HEADER_SIZE      6
 
 /* Period to update adv packets in microseconds */
-#define HUBBLE_ADV_PACKET_PERIOD   180000000UL
+#define HUBBLE_ADV_PACKET_PERIOD 180000000UL
 
 static uint8 bleAdvHandle;
 static uint8_t advData[BLE_ADV_LEN] = {HUBBLE_BLE_ADV_HEADER};
@@ -97,7 +97,7 @@ static void hubble_ble_adv_update(void *arg)
 {
 	(void)arg;
 
-	size_t len = BLE_ADV_LEN - HUBBLE_BLE_ADV_HEADER_SIZE;
+	size_t len = BLE_ADV_LEN - BLE_ADV_HEADER_SIZE;
 	int status = hubble_ble_advertise_get(
 		NULL, 0, &advData[HUBBLE_BLE_ADV_HEADER_SIZE], &len);
 
@@ -142,7 +142,7 @@ bStatus_t hubble_ble_adv_start(void)
 		return (FAILURE);
 	}
 
-	len = BLE_ADV_LEN - HUBBLE_BLE_ADV_HEADER_SIZE;
+	len = BLE_ADV_LEN - BLE_ADV_HEADER_SIZE;
 	if (hubble_ble_advertise_get(
 		    NULL, 0, &advData[HUBBLE_BLE_ADV_HEADER_SIZE], &len) != 0) {
 		return (FAILURE);

--- a/samples/freertos/ti/ble-beacon/src/hubble_config.h
+++ b/samples/freertos/ti/ble-beacon/src/hubble_config.h
@@ -7,8 +7,7 @@
 #ifndef SRC_HUBBLE_CONFIG_H
 #define SRC_HUBBLE_CONFIG_H
 
-#define CONFIG_HUBBLE_BLE_NETWORK             1
-#define CONFIG_HUBBLE_SAT_NETWORK             0
+#define CONFIG_HUBBLE_BLE_NETWORK              1
 
 #define CONFIG_HUBBLE_KEY_SIZE                16
 


### PR DESCRIPTION
- Fix build issue introduced when bumping SDK in the beacon sample
- Fix symbol redefinition in the beacon sample
- Do not define preprocessor symbol to 0 in the case where it should not be defined.