### PR TITLE
sat: ephemeris: Fix issue in pass prediction

### DIFF
--- a/src/hubble_sat_ephemeris.c
+++ b/src/hubble_sat_ephemeris.c
@@ -527,7 +527,7 @@ static int _pass_get(const struct hubble_sat_orbital_params *orbit, uint64_t t,
 		return -1;
 	}
 
-	while (crossings[0].t <= t) {
+	while ((crossings[0].t <= t) && (crossings[1].t <= t)) {
 		orbit_count++;
 		if (_tll_crossings_get(orbit, pos->lat, orbit_count,
 				       crossings) != 0) {


### PR DESCRIPTION
The fix adds && (crossings[1].t <= t) in _pass_get() so the loop continues only when both crossings are in the past — preventing it from consuming a pair where the second crossing (the descending node) is still in the future, which would skip a valid upcoming pass.