### PR TITLE
sat: Fix preamble signature

### DIFF
--- a/include/hubble/port/sat_radio.h
+++ b/include/hubble/port/sat_radio.h
@@ -61,7 +61,8 @@ extern "C" {
  * - -1: no transmission
  * -  31: center channel frequency
  */
-#define HUBBLE_SAT_PREAMBLE_SEQUENCE (int8_t[]){63, 0, 63, 0, 63, 0, 63, 63}
+#define HUBBLE_SAT_PREAMBLE_SEQUENCE                                           \
+	(const int8_t[]){63, 0, 63, 0, 63, 0, 63, 63}
 
 /**
  * @brief Initialize the satellite radio port.


### PR DESCRIPTION
Define PREAMBLE_SEQUENCE as const to avoid compiler errors.