### PR TITLE
sat: dtm: Add APIs to DTM

### DIFF
--- a/include/hubble/port/sat_radio.h
+++ b/include/hubble/port/sat_radio.h
@@ -96,6 +96,59 @@ int hubble_sat_port_packet_send(const struct hubble_sat_packet *packet,
 				uint8_t retries, uint8_t interval_s);
 
 /**
+ * @brief Transmit a DTM test packet over the satellite radio.
+ *
+ * Platform-specific implementation for sending a single DTM packet on the
+ * specified channel. When @p channel is -1, the transmission follows the
+ * standard channel-hopping scheme used by @ref hubble_sat_port_packet_send.
+ *
+ * @param packet  Pointer to the packet structure containing the data to transmit.
+ * @param channel RF channel to transmit on. -1 to hop between channels.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL Invalid channel.
+ */
+int hubble_sat_dtm_port_packet_send(const struct hubble_sat_packet *packet,
+				    int8_t channel);
+
+/**
+ * @brief Set the transmit power level (port implementation).
+ *
+ * Platform-specific implementation for configuring the output power used
+ * for subsequent DTM transmissions.
+ *
+ * @param power Desired TX power in dBm.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL Power level is out of the supported range.
+ */
+int hubble_sat_dtm_port_power_set(int8_t power);
+
+/**
+ * @brief Start continuous wave (CW) transmission (port implementation).
+ *
+ * Platform-specific implementation that begins transmitting an unmodulated
+ * carrier on the specified channel. Call @ref hubble_sat_dtm_port_cw_stop
+ * to end the transmission.
+ *
+ * @param channel RF channel index to transmit on.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL Invalid channel.
+ */
+int hubble_sat_dtm_port_cw_start(uint8_t channel);
+
+/**
+ * @brief Stop continuous wave (CW) transmission (port implementation).
+ *
+ * Platform-specific implementation that halts the unmodulated carrier
+ * started by @ref hubble_sat_dtm_port_cw_start.
+ *
+ * @retval 0    Success.
+ */
+int hubble_sat_dtm_port_cw_stop(void);
+
+/**
  * @}
  */
 

--- a/include/hubble/sat/dtm.h
+++ b/include/hubble/sat/dtm.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+/**
+ * @file dtm.h
+ * @brief Hubble Network DTM (Direct Test Mode) APIs
+ *
+ * This module provides APIs for Direct Test Mode, which allows testing
+ * the radio physical layer by transmitting test packets on
+ * a specified channel or hopping.
+ **/
+
+#ifndef INCLUDE_HUBBLE_SAT_DTM_H
+#define INCLUDE_HUBBLE_SAT_DTM_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief DTM packet type.
+ *
+ * Selects the test packet payload size to transmit during DTM.
+ * All the payload is random bytes.
+ */
+enum hubble_sat_dtm_packet_type {
+	HUBBLE_SAT_DTM_PACKET_0,
+	HUBBLE_SAT_DTM_PACKET_4,
+	HUBBLE_SAT_DTM_PACKET_9,
+	HUBBLE_SAT_DTM_PACKET_13,
+};
+
+/**
+ * @brief Send a DTM test packet.
+ *
+ * Transmits a single DTM packet of the given type on the specified channel.
+ *
+ * @note channel equals -1 means regular transmission as it is done with
+ * @ref hubble_sat_packet_send
+ *
+ * @param type    Packet payload pattern to use.
+ * @param channel RF channel to transmit on. -1 to hop between channels.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL Invalid channel or packet type.
+ */
+int hubble_sat_dtm_packet_send(enum hubble_sat_dtm_packet_type type,
+			       int8_t channel);
+
+/**
+ * @brief Set the transmit power level.
+ *
+ * Configures the output power used for subsequent DTM transmissions.
+ *
+ * @param power Desired TX power in dBm.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL Power level is out of the supported range.
+ */
+int hubble_sat_dtm_power_set(int8_t power);
+
+/**
+ * @brief Start continuous wave (CW) transmission.
+ *
+ * Begins transmitting an unmodulated carrier on the specified channel.
+ * Call @ref hubble_sat_dtm_cw_stop to end the transmission.
+ *
+ * @param channel RF channel index to transmit on.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL Invalid channel.
+ */
+int hubble_sat_dtm_cw_start(uint8_t channel);
+
+/**
+ * @brief Stop continuous wave (CW) transmission.
+ *
+ * Halts the unmodulated carrier started by @ref hubble_sat_dtm_cw_start.
+ *
+ * @retval 0    Success.
+ */
+int hubble_sat_dtm_cw_stop(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INCLUDE_HUBBLE_SAT_DTM_H */

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -82,6 +82,12 @@ config HUBBLE_SAT_NETWORK_DEVICE_TDR
 	  Default of 500 PPM is suitable for typical crystal
 	  oscillators.
 
+config HUBBLE_SAT_NETWORK_DTM_MODE
+	bool "Enable DTM mode"
+	help
+	  Enable DTM mode in the SDK. It is intended
+	  to test the operation of radio.
+
 choice
 	prompt "Hubble Sat Network protocol"
 	default HUBBLE_SAT_NETWORK_PROTOCOL_V1

--- a/port/zephyr/hubble_sat_zephyr.c
+++ b/port/zephyr/hubble_sat_zephyr.c
@@ -83,3 +83,80 @@ int hubble_sat_port_init(void)
 {
 	return hubble_sat_board_init();
 }
+
+#ifdef CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE
+
+int hubble_sat_dtm_port_packet_send(const struct hubble_sat_packet *packet,
+				    int8_t channel)
+{
+	int ret;
+	struct hubble_sat_packet_frames frames = {0};
+
+	if ((channel < -1) || (channel >= HUBBLE_SAT_NUM_CHANNELS)) {
+		return -EINVAL;
+	}
+
+	ret = hubble_sat_packet_frames_get(packet, &frames);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (channel != -1) {
+		for (uint8_t i = 0; i < HUBBLE_PACKET_FRAME_MAX_SIZE; i++) {
+			frames.frame[i].channel = channel;
+		}
+	}
+
+	ret = hubble_sat_board_enable();
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = hubble_sat_board_packet_send(&frames);
+	if (ret != 0) {
+		(void)hubble_sat_board_disable();
+		return ret;
+	}
+
+	return hubble_sat_board_disable();
+}
+
+int hubble_sat_dtm_port_power_set(int8_t power)
+{
+	return hubble_sat_board_power_set(power);
+}
+
+int hubble_sat_dtm_port_cw_start(uint8_t channel)
+{
+	int ret;
+
+	if (channel >= HUBBLE_SAT_NUM_CHANNELS) {
+		return -EINVAL;
+	}
+
+	ret = hubble_sat_board_enable();
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = hubble_sat_board_cw_start(channel);
+	if (ret != 0) {
+		(void)hubble_sat_board_disable();
+		return ret;
+	}
+
+	return 0;
+}
+
+int hubble_sat_dtm_port_cw_stop(void)
+{
+	int ret = hubble_sat_board_cw_stop();
+	if (ret != 0) {
+		(void)hubble_sat_board_disable();
+		return ret;
+	}
+
+	return hubble_sat_board_disable();
+}
+
+#endif /* CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE */

--- a/port/zephyr/sat_board.h
+++ b/port/zephyr/sat_board.h
@@ -78,6 +78,31 @@ int hubble_sat_board_disable(void);
  */
 int hubble_sat_board_packet_send(const struct hubble_sat_packet_frames *packet);
 
+/**
+ * @brief Set the transmit power level.
+ *
+ * @param power Desired TX power in dBm.
+ *
+ * @return 0 on success, or a negative error code if the power level is out of range.
+ */
+int hubble_sat_board_power_set(int8_t power);
+
+/**
+ * @brief Start continuous wave (CW) transmission on the specified channel.
+ *
+ * @param channel RF channel index to transmit on.
+ *
+ * @return 0 on success, or a negative error code if the channel is invalid.
+ */
+int hubble_sat_board_cw_start(uint8_t channel);
+
+/**
+ * @brief Stop continuous wave (CW) transmission.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int hubble_sat_board_cw_stop(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hubble_sat.c
+++ b/src/hubble_sat.c
@@ -12,6 +12,10 @@
 #include <hubble/port/sys.h>
 #include <hubble/port/sat_radio.h>
 
+#ifdef CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE
+#include <hubble/sat/dtm.h>
+#endif
+
 #include "hubble_priv.h"
 #include "utils/macros.h"
 
@@ -113,3 +117,58 @@ int hubble_sat_packet_send(const struct hubble_sat_packet *packet,
 
 	return 0;
 }
+
+#ifdef CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE
+
+int hubble_sat_dtm_packet_send(enum hubble_sat_dtm_packet_type type,
+			       int8_t channel)
+{
+	struct hubble_sat_packet packet;
+	/* Hold max possible user data */
+	char buffer[13];
+	uint8_t len;
+	int ret;
+
+	switch (type) {
+	case HUBBLE_SAT_DTM_PACKET_0:
+		len = 0;
+		break;
+	case HUBBLE_SAT_DTM_PACKET_4:
+		len = 4;
+		break;
+	case HUBBLE_SAT_DTM_PACKET_9:
+		len = 9;
+		break;
+	case HUBBLE_SAT_DTM_PACKET_13:
+		len = 13;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	hubble_rand_get(buffer, len);
+
+	ret = hubble_sat_packet_get(&packet, buffer, len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return hubble_sat_dtm_port_packet_send(&packet, channel);
+}
+
+int hubble_sat_dtm_power_set(int8_t power)
+{
+	return hubble_sat_dtm_port_power_set(power);
+}
+
+int hubble_sat_dtm_cw_start(uint8_t channel)
+{
+	return hubble_sat_dtm_port_cw_start(channel);
+}
+
+int hubble_sat_dtm_cw_stop(void)
+{
+	return hubble_sat_dtm_port_cw_stop();
+}
+
+#endif


### PR DESCRIPTION
DTM is needed to test the operation of radio. It uses the same Bluetooth terminology and some similar APIs but it is tailored to Hubble protocol.