### PR TITLE
ci: esp-idf: build for all esp-idf samples with footprint report

### DIFF
--- a/.github/workflows/build-samples-esp-idf.yaml
+++ b/.github/workflows/build-samples-esp-idf.yaml
@@ -1,4 +1,4 @@
-name: Build ESP-IDF Ble-Beacon Sample
+name: Build ESP-IDF Samples
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    name: Build ESP-IDF Ble-Beacon Sample App
+    name: Build ESP-IDF Sample Apps
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -32,14 +32,91 @@ jobs:
         with:
           submodules: 'recursive'
 
+      # only need for the beacon sample, but simpler to do once here
       - name: Generate key and time
         run: |
           echo -n "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" > master.key
           python3 tools/embed_key_time.py -b master.key -o samples/esp-idf/ble-beacon/main/
 
-      - name: esp-idf build
+      - name: Build all samples and generate component size
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: "latest"
           target: ${{ matrix.espidf_target }}
-          path: 'samples/esp-idf/ble-beacon'
+          command: |
+            set -euxo pipefail
+            pip install idf-build-apps
+            idf-build-apps build -p samples/esp-idf --recursive --target ${{ matrix.espidf_target }}
+            for app in samples/esp-idf/*/; do
+              app_name=$(basename "$app")
+              target=${{ matrix.espidf_target }}
+              (cd "$app" && \
+                 idf.py size-components --format json2 \
+                   --output-file "size-components-${app_name}-${target}.json" && \
+                 idf.py size-files --format json2 \
+                   --output-file "size-files-${app_name}-${target}.json")
+            done
+            idf.py --version > samples/esp-idf/idf-version.txt
+
+      - name: Stage footprint artifacts
+        if: always()
+        run: |
+          set -euxo pipefail
+          mkdir -p esp-idf-footprint-out
+          # Collect every size-* JSON the build emitted across all samples.
+          find samples/esp-idf -maxdepth 2 \
+            \( -name "size-components-*.json" -o -name "size-files-*.json" \) \
+            -exec cp {} esp-idf-footprint-out/ \;
+          if [ -f samples/esp-idf/idf-version.txt ]; then
+            cp samples/esp-idf/idf-version.txt \
+               esp-idf-footprint-out/idf-version.txt
+          fi
+
+      - name: Upload footprint artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: footprint-${{ matrix.espidf_target }}
+          path: esp-idf-footprint-out/
+          if-no-files-found: warn
+
+  footprint-summary:
+    name: Footprint Summary
+    needs: build
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download all footprint artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: footprint-artifacts
+          pattern: footprint-*
+          merge-multiple: true
+
+      - name: Resolve revision and ESP-IDF version
+        id: meta
+        run: |
+          set -euxo pipefail
+          echo "revision=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          if [ -f footprint-artifacts/idf-version.txt ]; then
+            idf_version=$(head -n1 footprint-artifacts/idf-version.txt | tr -d '\r')
+          else
+            idf_version=unknown
+          fi
+          echo "idf_version=${idf_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Print footprint table to log
+        run: |
+          python3 tools/ci/summarize_footprint_esp_idf.py footprint-artifacts \
+            --revision "${{ steps.meta.outputs.revision }}" \
+            --idf-version "${{ steps.meta.outputs.idf_version }}"
+
+      - name: Render footprint summary in GitHub UI
+        run: |
+          python3 tools/ci/summarize_footprint_esp_idf.py footprint-artifacts \
+            --revision "${{ steps.meta.outputs.revision }}" \
+            --idf-version "${{ steps.meta.outputs.idf_version }}" \
+            --format markdown >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-samples-esp-idf.yaml
+++ b/.github/workflows/build-samples-esp-idf.yaml
@@ -1,4 +1,4 @@
-name: Build ESP-IDF Ble-Beacon Sample
+name: Build ESP-IDF Samples
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    name: Build ESP-IDF Ble-Beacon Sample App
+    name: Build ESP-IDF Sample Apps
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -32,14 +32,91 @@ jobs:
         with:
           submodules: 'recursive'
 
+      # only need for the beacon sample, but simpler to do once here
       - name: Generate key and time
         run: |
           echo -n "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" > master.key
           python3 tools/embed_key_time.py -b master.key -o samples/esp-idf/ble-beacon/main/
 
-      - name: esp-idf build
+      - name: Build all samples and generate component size
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: "latest"
           target: ${{ matrix.espidf_target }}
-          path: 'samples/esp-idf/ble-beacon'
+          command: |
+            set -euxo pipefail
+            pip install idf-build-apps
+            idf-build-apps build -p samples/esp-idf --recursive --target ${{ matrix.espidf_target }}
+            for app in samples/esp-idf/*/; do
+              app_name=$(basename "$app")
+              target=${{ matrix.espidf_target }}
+              (cd "$app" && \
+                 idf.py size-components --format json2 \
+                   --output-file "size-components-${app_name}-${target}.json" && \
+                 idf.py size-files --format json2 \
+                   --output-file "size-files-${app_name}-${target}.json")
+            done
+            idf.py --version > samples/esp-idf/idf-version.txt
+
+      - name: Stage footprint artifacts
+        if: always()
+        run: |
+          set -euxo pipefail
+          mkdir -p esp-idf-footprint-out
+          # Collect every size-* JSON the build emitted across all samples.
+          find samples/esp-idf -maxdepth 2 \
+            \( -name "size-components-*.json" -o -name "size-files-*.json" \) \
+            -exec cp {} esp-idf-footprint-out/ \;
+          if [ -f samples/esp-idf/idf-version.txt ]; then
+            cp samples/esp-idf/idf-version.txt \
+               esp-idf-footprint-out/idf-version.txt
+          fi
+
+      - name: Upload footprint artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: footprint-${{ matrix.espidf_target }}
+          path: esp-idf-footprint-out/
+          if-no-files-found: ignore
+
+  footprint-summary:
+    name: Footprint Summary
+    needs: build
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download all footprint artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: footprint-artifacts
+          pattern: footprint-*
+          merge-multiple: true
+
+      - name: Resolve revision and ESP-IDF version
+        id: meta
+        run: |
+          set -euxo pipefail
+          echo "revision=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          if [ -f footprint-artifacts/idf-version.txt ]; then
+            idf_version=$(head -n1 footprint-artifacts/idf-version.txt | tr -d '\r')
+          else
+            idf_version=unknown
+          fi
+          echo "idf_version=${idf_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Print footprint table to log
+        run: |
+          python3 tools/ci/summarize_footprint_esp_idf.py footprint-artifacts \
+            --revision "${{ steps.meta.outputs.revision }}" \
+            --idf-version "${{ steps.meta.outputs.idf_version }}"
+
+      - name: Render footprint summary in GitHub UI
+        run: |
+          python3 tools/ci/summarize_footprint_esp_idf.py footprint-artifacts \
+            --revision "${{ steps.meta.outputs.revision }}" \
+            --idf-version "${{ steps.meta.outputs.idf_version }}" \
+            --format markdown >> "$GITHUB_STEP_SUMMARY"

--- a/tools/ci/summarize_footprint_esp_idf.py
+++ b/tools/ci/summarize_footprint_esp_idf.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Hubble Network, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Summarize RAM and ROM per ESP-IDF sample/target.
+
+Usage:
+    summarize_footprint_esp_idf.py <artifacts_dir>
+        [--revision REVISION] [--idf-version IDF_VERSION] [--format FORMAT]
+
+Note:
+    Expects JSONs named:
+        size-components-<sample>-<target>.json
+        size-files-<sample>-<target>.json
+    <sample> may contain hyphens; <target> never does.
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SAMPLE_COLUMN_SIZE = 30
+TARGET_COLUMN_SIZE = 25
+ROM_COLUMN_SIZE = 15
+RAM_COLUMN_SIZE = 15
+TOTAL_COLUMN_SIZE = (
+    SAMPLE_COLUMN_SIZE + TARGET_COLUMN_SIZE + ROM_COLUMN_SIZE + RAM_COLUMN_SIZE
+)
+
+# TODO: find a better way for this
+# but ESP-IDF emits the individual RAM and ROM name, so we have
+# the allow list here (would get out of hand pretty quick though)
+ROM_MEMORY_TYPES = ("Flash Code", "Flash Data")
+RAM_MEMORY_TYPES = ("DIRAM", "DRAM", "IRAM", "LP SRAM", "RTC SLOW", "RTC FAST")
+
+# Port directories that contributes to esp-idf
+PORT_DIRS = (
+    "port/esp-idf",
+    "port/freertos",
+)
+
+SDK_COMPONENT_ARCHIVE = "libhubblenetwork-sdk.a"
+SIZE_COMPONENTS_FROM_FILENAME = re.compile(r"size-components-(.+)-([^-]+)\.json$")
+
+
+def format_size(size_bytes):
+    """Format size in bytes to human-readable format."""
+    if size_bytes is None or size_bytes < 0:
+        return "N/A"
+    for unit in ["B", "KB", "MB"]:
+        if size_bytes < 1024.0:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024.0
+    return f"{size_bytes:.2f} GB"
+
+
+def memory_size_extract(memory_types):
+    """Return (rom, ram) bytes from a memory_types dict."""
+    rom = sum(memory_types.get(k, {}).get("size", 0) for k in ROM_MEMORY_TYPES)
+    ram = sum(memory_types.get(k, {}).get("size", 0) for k in RAM_MEMORY_TYPES)
+    return rom, ram
+
+
+def sdk_total_extract(size_data):
+    """
+    Sum ROM and RAM for hubblenetwork-sdk component.
+    2 cases:
+    - collect the component size it self in size-components
+    - collect the port size in size-files
+    """
+    rom_total = 0
+    ram_total = 0
+    matched = False
+    for path, entry in size_data.items():
+        is_archive_level = entry.get("abbrev_name") == SDK_COMPONENT_ARCHIVE
+        is_file_in_sdk = SDK_COMPONENT_ARCHIVE in path
+        if not (is_archive_level or is_file_in_sdk):
+            continue
+        rom, ram = memory_size_extract(entry.get("memory_types", {}))
+        rom_total += rom
+        ram_total += ram
+        matched = True
+
+        # An archive-level entry already aggregates everything.
+        if is_archive_level:
+            return rom_total, ram_total
+    if not matched:
+        return None, None
+    return rom_total, ram_total
+
+
+def port_file_names_collect(port_dirs):
+    """
+    Collect all the .c files under the port
+    """
+    result = {}
+    for port_dir in port_dirs:
+        path = Path(port_dir)
+        if not path.is_dir():
+            continue
+        basenames = {c_file.stem + ".c.obj" for c_file in path.rglob("*.c")}
+        if basenames:
+            result[port_dir] = basenames
+    return result
+
+
+def port_footprints_extract(size_data, port_file_names_by_label):
+    """
+    Pulling ROM and RAM from the port files and sum them up.
+    Returns a list of (port_label, rom, ram)
+    """
+    results = []
+    for label, file_names in port_file_names_by_label.items():
+        rom_total = 0
+        ram_total = 0
+        for _, entry in size_data.items():
+            if entry.get("abbrev_name") not in file_names:
+                continue
+            rom, ram = memory_size_extract(entry.get("memory_types", {}))
+            rom_total += rom
+            ram_total += ram
+        results.append((label, rom_total, ram_total))
+    return results
+
+
+def json_load(path):
+    """Load JSON with error checking"""
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Warning: could not read {path}: {e}", file=sys.stderr)
+        return None
+
+
+def entries_collect(artifacts_dir, port_file_names_by_label):
+    """
+    Parse artifacts (json files) and extract entries for the report
+    (sample, target, rom, ram, ports)
+    """
+    entries = []
+    artifacts_path = Path(artifacts_dir)
+    for components_path in sorted(artifacts_path.rglob("size-components-*.json")):
+        match = SIZE_COMPONENTS_FROM_FILENAME.search(components_path.name)
+        if not match:
+            print(
+                f"Warning: skipping unrecognized filename: {components_path.name}",
+                file=sys.stderr,
+            )
+            continue
+        sample, target = match.group(1), match.group(2)
+
+        # Total SDK footprint comes from size-components
+        components_data = json_load(components_path) or {}
+        rom, ram = sdk_total_extract(components_data)
+
+        # Port files breakdown comes from size-files
+        ports = []
+        files_path = components_path.parent / f"size-files-{sample}-{target}.json"
+        if files_path.exists():
+            files_data = json_load(files_path)
+            if files_data:
+                ports = port_footprints_extract(files_data, port_file_names_by_label)
+
+        entries.append((sample, target, rom, ram, ports))
+    return entries
+
+
+def format_table(entries, revision, idf_version, run_date):
+    """Output as plain-text table"""
+    print()
+    print("hubblenetwork-sdk Footprint Summary")
+    print("=" * TOTAL_COLUMN_SIZE)
+    print(f"Archive:         {SDK_COMPONENT_ARCHIVE}")
+    print(f"Revision:        {revision}")
+    print(f"ESP-IDF Version: {idf_version}")
+    print(f"Run Date:        {run_date}")
+    print("=" * TOTAL_COLUMN_SIZE)
+    print(
+        f"{'Sample':<{SAMPLE_COLUMN_SIZE}}{'Target':<{TARGET_COLUMN_SIZE}}"
+        f"{'ROM':<{ROM_COLUMN_SIZE}}{'RAM':<{RAM_COLUMN_SIZE}}"
+    )
+    print("-" * TOTAL_COLUMN_SIZE)
+    for sample, target, rom, ram, ports in entries:
+        print(f"{sample:<{SAMPLE_COLUMN_SIZE}}{target:<{TARGET_COLUMN_SIZE}}")
+
+        indent = " " * SAMPLE_COLUMN_SIZE
+        print(
+            f"{indent}{'Hubblenetwork-SDK:':<{TARGET_COLUMN_SIZE}}"
+            f"{format_size(rom):<{ROM_COLUMN_SIZE}}"
+            f"{format_size(ram):<{RAM_COLUMN_SIZE}}"
+        )
+
+        # Per-port sub-rows under Hubblenetwork-SDK
+        for label, port_rom, port_ram in ports:
+            print(
+                f"{indent}{'    ' + label + ':':<{TARGET_COLUMN_SIZE}}"
+                f"{format_size(port_rom):<{ROM_COLUMN_SIZE}}"
+                f"{format_size(port_ram):<{RAM_COLUMN_SIZE}}"
+            )
+    print("-" * TOTAL_COLUMN_SIZE)
+    print(f"\nSummary: {len(entries)} build(s) processed")
+    print("=" * TOTAL_COLUMN_SIZE)
+
+
+def format_csv(entries, revision, idf_version):
+    """
+    Output CSV
+    """
+    print(
+        "Sample,Target,Component,"
+        "ROM (bytes),RAM (bytes),"
+        "ROM (formatted),RAM (formatted),"
+        "Revision,ESP-IDF Version"
+    )
+
+    def s(v):
+        return str(v) if v is not None else "N/A"
+
+    for sample, target, rom, ram, ports in entries:
+        print(
+            f"{sample},{target},total,"
+            f"{s(rom)},{s(ram)},"
+            f"{format_size(rom)},{format_size(ram)},"
+            f"{revision},{idf_version}"
+        )
+        for label, port_rom, port_ram in ports:
+            print(
+                f"{sample},{target},{label},"
+                f"{s(port_rom)},{s(port_ram)},"
+                f"{format_size(port_rom)},{format_size(port_ram)},"
+                f"{revision},{idf_version}"
+            )
+
+
+def format_markdown(entries, revision, idf_version, run_date):
+    """
+    Output markdown for $GITHUB_STEP_SUMMARY
+    """
+    print("## hubblenetwork-sdk Footprint Summary")
+    print()
+    print(f"- **Archive:** `{SDK_COMPONENT_ARCHIVE}`")
+    print(f"- **Revision:** `{revision}`")
+    print(f"- **ESP-IDF Version:** {idf_version}")
+    print(f"- **Run Date:** {run_date}")
+    print()
+    print("| Sample | Target | Component | ROM | RAM |")
+    print("|---|---|---|---|---|")
+    for sample, target, rom, ram, ports in entries:
+        print(
+            f"| {sample} | {target} | **total** "
+            f"| {format_size(rom)} | {format_size(ram)} |"
+        )
+        for label, port_rom, port_ram in ports:
+            print(
+                f"| {sample} | {target} | {label} "
+                f"| {format_size(port_rom)} | {format_size(port_ram)} |"
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Summarize hubblenetwork-sdk RAM/ROM from idf.py size output"
+    )
+    parser.add_argument(
+        "artifacts_dir",
+        help="Directory containing size-components-<sample>-<target>.json "
+        "and size-files-<sample>-<target>.json files",
+    )
+    parser.add_argument(
+        "--revision",
+        default="unknown",
+        help="SDK Git revision (short SHA) to print in the header",
+    )
+    parser.add_argument(
+        "--idf-version",
+        default="unknown",
+        help="ESP-IDF version string to print in the header",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "csv", "markdown"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    args = parser.parse_args()
+
+    artifacts_path = Path(args.artifacts_dir)
+    if not artifacts_path.is_dir():
+        print(f"Error: directory not found: {args.artifacts_dir}", file=sys.stderr)
+        return 1
+
+    port_file_names_by_label = port_file_names_collect(PORT_DIRS)
+    if not port_file_names_by_label:
+        print(
+            f"Warning: no .c files found under any of: {', '.join(PORT_DIRS)}; "
+            f"port breakdown will be skipped.",
+            file=sys.stderr,
+        )
+
+    entries = entries_collect(artifacts_path, port_file_names_by_label)
+    if not entries:
+        print(
+            f"Warning: no size-components-*.json files found under "
+            f"{args.artifacts_dir}",
+            file=sys.stderr,
+        )
+        return 0
+
+    run_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    if args.format == "csv":
+        format_csv(entries, args.revision, args.idf_version)
+    elif args.format == "markdown":
+        format_markdown(entries, args.revision, args.idf_version, run_date)
+    else:
+        format_table(entries, args.revision, args.idf_version, run_date)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci/summarize_footprint_esp_idf.py
+++ b/tools/ci/summarize_footprint_esp_idf.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Hubble Network, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Summarize RAM and ROM per ESP-IDF sample/target.
+
+Usage:
+    summarize_footprint_esp_idf.py <artifacts_dir>
+        [--revision REVISION] [--idf-version IDF_VERSION] [--format FORMAT]
+
+Note:
+    Expects JSONs named:
+        size-components-<sample>-<target>.json
+        size-files-<sample>-<target>.json
+    <sample> may contain hyphens; <target> never does.
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SAMPLE_COLUMN_SIZE = 30
+TARGET_COLUMN_SIZE = 25
+ROM_COLUMN_SIZE = 15
+RAM_COLUMN_SIZE = 15
+TOTAL_COLUMN_SIZE = (
+    SAMPLE_COLUMN_SIZE + TARGET_COLUMN_SIZE + ROM_COLUMN_SIZE + RAM_COLUMN_SIZE
+)
+
+# TODO: find a better way for this
+# but ESP-IDF emits the individual RAM and ROM name, so we have
+# the allow list here (would get out of hand pretty quick though)
+ROM_MEMORY_TYPES = ("Flash Code", "Flash Data")
+RAM_MEMORY_TYPES = ("DIRAM", "DRAM", "IRAM", "LP SRAM", "RTC SLOW", "RTC FAST")
+
+# Port directories that contributes to esp-idf
+PORT_DIRS = (
+    "port/esp-idf",
+    "port/freertos",
+)
+SDK_COMPONENT_ARCHIVE = "libhubblenetwork-sdk.a"
+
+SIZE_COMPONENTS_FROM_FILENAME = re.compile(r"size-components-(.+)-([^-]+)\.json$")
+SIZE_FILES_FROM_FILENAME = re.compile(r"size-files-(.+)-([^-]+)\.json$")
+
+
+def format_size(size_bytes):
+    """Format size in bytes to human-readable format."""
+    if size_bytes is None or size_bytes < 0:
+        return "N/A"
+    for unit in ["B", "KB", "MB"]:
+        if size_bytes < 1024.0:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024.0
+    return f"{size_bytes:.2f} GB"
+
+
+def memory_size_extract(memory_types):
+    """Return (rom, ram) bytes from a memory_types dict."""
+    rom = sum(memory_types.get(k, {}).get("size", 0) for k in ROM_MEMORY_TYPES)
+    ram = sum(memory_types.get(k, {}).get("size", 0) for k in RAM_MEMORY_TYPES)
+    return rom, ram
+
+
+def sdk_total_extract(size_data):
+    """
+    Sum ROM and RAM for hubblenetwork-sdk component.
+    2 cases:
+    - collect the component size it self in size-components
+    - collect the port size in size-files
+    """
+    rom_total = 0
+    ram_total = 0
+    matched = False
+    for path, entry in size_data.items():
+        is_archive_level = entry.get("abbrev_name") == SDK_COMPONENT_ARCHIVE
+        is_file_in_sdk = SDK_COMPONENT_ARCHIVE in path
+        if not (is_archive_level or is_file_in_sdk):
+            continue
+        rom, ram = memory_size_extract(entry.get("memory_types", {}))
+        rom_total += rom
+        ram_total += ram
+        matched = True
+
+        # An archive-level entry already aggregates everything.
+        if is_archive_level:
+            return rom_total, ram_total
+    if not matched:
+        return None, None
+    return rom_total, ram_total
+
+
+def port_file_names_collect(port_dirs):
+    """
+    Collect all the .c files under the port
+    """
+    result = {}
+    for port_dir in port_dirs:
+        path = Path(port_dir)
+        if not path.is_dir():
+            continue
+        basenames = {c_file.stem + ".c.obj" for c_file in path.rglob("*.c")}
+        if basenames:
+            result[port_dir] = basenames
+    return result
+
+
+def port_footprints_extract(size_data, port_file_names_by_label):
+    """
+    Pulling ROM and RAM from the port files and sum them up.
+    Returns a list of (port_label, rom, ram)
+    """
+    results = []
+    for label, file_names in port_file_names_by_label.items():
+        rom_total = 0
+        ram_total = 0
+        for _, entry in size_data.items():
+            if entry.get("abbrev_name") not in file_names:
+                continue
+            rom, ram = memory_size_extract(entry.get("memory_types", {}))
+            rom_total += rom
+            ram_total += ram
+        results.append((label, rom_total, ram_total))
+    return results
+
+
+def json_load(path):
+    """Load JSON with error checking"""
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Warning: could not read {path}: {e}", file=sys.stderr)
+        return None
+
+
+def entries_collect(artifacts_dir, port_file_names_by_label):
+    """
+    Parse artifacts (json files) and extract entries for the report
+    (sample, target, rom, ram, ports)
+    """
+    entries = []
+    artifacts_path = Path(artifacts_dir)
+    for components_path in sorted(artifacts_path.rglob("size-components-*.json")):
+        match = SIZE_COMPONENTS_FROM_FILENAME.search(components_path.name)
+        if not match:
+            print(
+                f"Warning: skipping unrecognized filename: {components_path.name}",
+                file=sys.stderr,
+            )
+            continue
+        sample, target = match.group(1), match.group(2)
+
+        # Total SDK footprint comes from size-components
+        components_data = json_load(components_path) or {}
+        rom, ram = sdk_total_extract(components_data)
+
+        # Port files breakdown comes from size-files
+        ports = []
+        files_path = components_path.parent / f"size-files-{sample}-{target}.json"
+        if files_path.exists():
+            files_data = json_load(files_path)
+            if files_data:
+                ports = port_footprints_extract(files_data, port_file_names_by_label)
+
+        entries.append((sample, target, rom, ram, ports))
+    return entries
+
+
+def format_table(entries, revision, idf_version, run_date):
+    """Output as plain-text table"""
+    print()
+    print("hubblenetwork-sdk Footprint Summary")
+    print("=" * TOTAL_COLUMN_SIZE)
+    print(f"Archive:         {SDK_COMPONENT_ARCHIVE}")
+    print(f"Revision:        {revision}")
+    print(f"ESP-IDF Version: {idf_version}")
+    print(f"Run Date:        {run_date}")
+    print("=" * TOTAL_COLUMN_SIZE)
+    print(
+        f"{'Sample':<{SAMPLE_COLUMN_SIZE}}{'Target':<{TARGET_COLUMN_SIZE}}"
+        f"{'ROM':<{ROM_COLUMN_SIZE}}{'RAM':<{RAM_COLUMN_SIZE}}"
+    )
+    print("-" * TOTAL_COLUMN_SIZE)
+    for sample, target, rom, ram, ports in entries:
+        print(f"{sample:<{SAMPLE_COLUMN_SIZE}}{target:<{TARGET_COLUMN_SIZE}}")
+
+        indent = " " * SAMPLE_COLUMN_SIZE
+        print(
+            f"{indent}{'Hubblenetwork-SDK:':<{TARGET_COLUMN_SIZE}}"
+            f"{format_size(rom):<{ROM_COLUMN_SIZE}}"
+            f"{format_size(ram):<{RAM_COLUMN_SIZE}}"
+        )
+
+        # Per-port sub-rows under Hubblenetwork-SDK
+        for label, port_rom, port_ram in ports:
+            print(
+                f"{indent}{'    ' + label + ':':<{TARGET_COLUMN_SIZE}}"
+                f"{format_size(port_rom):<{ROM_COLUMN_SIZE}}"
+                f"{format_size(port_ram):<{RAM_COLUMN_SIZE}}"
+            )
+    print("-" * TOTAL_COLUMN_SIZE)
+    print(f"\nSummary: {len(entries)} build(s) processed")
+    print("=" * TOTAL_COLUMN_SIZE)
+
+
+def format_csv(entries, revision, idf_version):
+    """
+    Output CSV
+    """
+    print(
+        "Sample,Target,Component,"
+        "ROM (bytes),RAM (bytes),"
+        "ROM (formatted),RAM (formatted),"
+        "Revision,ESP-IDF Version"
+    )
+
+    def s(v):
+        return str(v) if v is not None else "N/A"
+
+    for sample, target, rom, ram, ports in entries:
+        print(
+            f"{sample},{target},total,"
+            f"{s(rom)},{s(ram)},"
+            f"{format_size(rom)},{format_size(ram)},"
+            f"{revision},{idf_version}"
+        )
+        for label, port_rom, port_ram in ports:
+            print(
+                f"{sample},{target},{label},"
+                f"{s(port_rom)},{s(port_ram)},"
+                f"{format_size(port_rom)},{format_size(port_ram)},"
+                f"{revision},{idf_version}"
+            )
+
+
+def format_markdown(entries, revision, idf_version, run_date):
+    """
+    Output markdown for $GITHUB_STEP_SUMMARY
+    """
+    print("## hubblenetwork-sdk Footprint Summary")
+    print()
+    print(f"- **Archive:** `{SDK_COMPONENT_ARCHIVE}`")
+    print(f"- **Revision:** `{revision}`")
+    print(f"- **ESP-IDF Version:** {idf_version}")
+    print(f"- **Run Date:** {run_date}")
+    print()
+    print("| Sample | Target | Component | ROM | RAM |")
+    print("|---|---|---|---|---|")
+    for sample, target, rom, ram, ports in entries:
+        print(
+            f"| {sample} | {target} | **total** "
+            f"| {format_size(rom)} | {format_size(ram)} |"
+        )
+        for label, port_rom, port_ram in ports:
+            print(
+                f"| {sample} | {target} | {label} "
+                f"| {format_size(port_rom)} | {format_size(port_ram)} |"
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Summarize hubblenetwork-sdk RAM/ROM from idf.py size output"
+    )
+    parser.add_argument(
+        "artifacts_dir",
+        help="Directory containing size-components-<sample>-<target>.json "
+        "and size-files-<sample>-<target>.json files",
+    )
+    parser.add_argument(
+        "--revision",
+        default="unknown",
+        help="SDK Git revision (short SHA) to print in the header",
+    )
+    parser.add_argument(
+        "--idf-version",
+        default="unknown",
+        help="ESP-IDF version string to print in the header",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "csv", "markdown"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    args = parser.parse_args()
+
+    artifacts_path = Path(args.artifacts_dir)
+    if not artifacts_path.is_dir():
+        print(f"Error: directory not found: {args.artifacts_dir}", file=sys.stderr)
+        return 1
+
+    port_file_names_by_label = port_file_names_collect(PORT_DIRS)
+    if not port_file_names_by_label:
+        print(
+            f"Warning: no .c files found under any of: {', '.join(PORT_DIRS)}; "
+            f"port breakdown will be skipped.",
+            file=sys.stderr,
+        )
+
+    entries = entries_collect(artifacts_path, port_file_names_by_label)
+    if not entries:
+        print(
+            f"Warning: no size-components-*.json files found under "
+            f"{args.artifacts_dir}",
+            file=sys.stderr,
+        )
+        return 0
+
+    run_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    if args.format == "csv":
+        format_csv(entries, args.revision, args.idf_version)
+    elif args.format == "markdown":
+        format_markdown(entries, args.revision, args.idf_version, run_date)
+    else:
+        format_table(entries, args.revision, args.idf_version, run_date)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add footprint report to esp-idf port.

The plain-text will look like this:

```
hubblenetwork-sdk Footprint Summary
=====================================================================================
Archive:         libhubblenetwork-sdk.a
Revision:        c67feb9
ESP-IDF Version: ESP-IDF v6.1-dev-4427-gc00874869b
Run Date:        2026-05-01 23:24:01 UTC
=====================================================================================
Sample                        Target                   ROM            RAM            
-------------------------------------------------------------------------------------
ble-beacon                    esp32                    
                              Hubblenetwork-SDK:       2.21 KB        43.00 B        
                                  port/esp-idf:        7.00 B         0.00 B         
                                  port/freertos:       174.00 B       12.00 B        
ble-beacon                    esp32c6                  
                              Hubblenetwork-SDK:       2.63 KB        43.00 B        
                                  port/esp-idf:        20.00 B        0.00 B         
                                  port/freertos:       212.00 B       12.00 B        
ble-beacon                    esp32h2                  
                              Hubblenetwork-SDK:       2.63 KB        43.00 B        
                                  port/esp-idf:        20.00 B        0.00 B         
                                  port/freertos:       212.00 B       12.00 B        
ble-beacon                    esp32s3                  
                              Hubblenetwork-SDK:       2.21 KB        43.00 B        
                                  port/esp-idf:        7.00 B         0.00 B         
                                  port/freertos:       182.00 B       12.00 B        
-------------------------------------------------------------------------------------

Summary: 4 build(s) processed
=====================================================================================
```

And the Action Summary:

<img width="536" height="682" alt="Screenshot 2026-05-01 at 4 26 57 PM" src="https://github.com/user-attachments/assets/01a0e0ad-f9e9-49c6-948d-0ab978796cd5" />

