### PR TITLE
gh: actions/coverage: fix workflow failing after bump to zephyr 4.4.0

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -52,6 +52,8 @@ jobs:
           app-path: .
 
       - name: Generate Coverage Information
+        env:
+          ZEPHYR_TOOLCHAIN_VARIANT: zephyr
         run: |
           west twister -i --force-color -N -v --filter runnable \
             -p native_sim -p unit_testing --coverage \


### PR DESCRIPTION
zephyr introduced support for new toolchain variant syntax in commit zephyrproject-rtos/zephyr@3bf6c859efa64383699f8dee34e3b461a3d51fd6

especially this line:

```
- if os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT") == "llvm":
+ if os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT").endswith("/llvm"):
```


this causes any workflow that never sets ZEPHYR_TOOLCHAIN_VARIANT to fail, so we need to explicitly set it here in the workflow.