### PR TITLE
gitignore: Update with Zephyr blobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ docs/_doxygen/
 **/time.c
 **/sdkconfig
 **/sdkconfig.old
+
+# Blobs
+zephyr/blobs/nrf52
+zephyr/blobs/nrf53
+zephyr/blobs/nrf54


### PR DESCRIPTION
Update gitignore file to ignore blobs directory within SDK.