### PR TITLE
zephyr: boards: nrf54: clear RADIO SUBSCRIBE_RXEN on SoC enable

### DIFF
--- a/port/zephyr/boards/nordic/nrf54/nrf54_soc.c
+++ b/port/zephyr/boards/nordic/nrf54/nrf54_soc.c
@@ -178,6 +178,8 @@ int hubble_sat_soc_enable(void)
 
 	(void)hubble_nrf_lib_enable();
 
+	NRF_RADIO->SUBSCRIBE_RXEN = 0;
+
 	nrf_radio_fast_ramp_up_enable_set(NRF_RADIO, true);
 	nrf_radio_mode_set(NRF_RADIO, NRF_RADIO_MODE_BLE_1MBIT);
 	nrf_radio_shorts_enable(NRF_RADIO, NRF_RADIO_SHORT_READY_START_MASK);


### PR DESCRIPTION
In dual-stack configurations, the Bluetooth controller configures a DPPI subscription on RADIO.RXEN. If a BLE connection has been established, that subscription persists when the satellite stack takes over the radio, causing spurious RX enables once the radio is reconfigured for satellite operation.

Clear SUBSCRIBE_RXEN before applying the satellite radio configuration so the radio starts from a clean state regardless of prior BLE activity.