### PR TITLE
samples: ti/beacon: add log and fix wrong payload data

### DIFF
--- a/samples/freertos/ti/ble-beacon/README.md
+++ b/samples/freertos/ti/ble-beacon/README.md
@@ -73,6 +73,16 @@ make
 
    Flash the generated firmware (*ble-beacon.out*) onto the target device using your preferred flashing tool.
 
+5. **View Log**
+
+   View log using TI `tiutils`. See setup instruction at `<TI_SDK_INSTALL_DIR>/tools/log/tiutils/README.md`.
+
+   Example:
+
+```bash
+   tilogger --elf ./build/ble-beacon.out uart /dev/tty.usbmodemLS470FPO1 3000000 stdout
+```
+
 ### Usage
 
 Once the firmware is flashed:

--- a/samples/freertos/ti/ble-beacon/ble-beacon.syscfg
+++ b/samples/freertos/ti/ble-beacon/ble-beacon.syscfg
@@ -131,3 +131,32 @@ ble.basicBLE = true;
 /* ======== RNG ======== */
 var RNG = scripting.addModule("/ti/drivers/RNG");
 RNG.rngReturnBehavior = "RNG_RETURN_BEHAVIOR_BLOCKING";
+
+/**
+ * Import log module used in this configuration.
+ */
+const LogModule    = scripting.addModule("/ti/log/LogModule", {}, false);
+const LogModule1   = LogModule.addInstance();
+const LogSinkUART  = scripting.addModule("/ti/log/LogSinkUART", {}, false);
+const LogSinkUART1 = LogSinkUART.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+LogModule1.$name      = "LogModule_Beacon";
+LogModule1.loggerSink = "/ti/log/LogSinkUART";
+
+LogSinkUART1.$name          = "CONFIG_ti_log_LogSinkUART_0";
+LogModule1.logger           = LogSinkUART1;
+LogSinkUART1.uart.$name     = "CONFIG_UART2_0";
+LogSinkUART1.uart.$hardware = system.deviceData.board.components.XDS110UART;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+LogSinkUART1.uart.uart.$suggestSolution              = "UART0";
+LogSinkUART1.uart.uart.dmaTxChannel.$suggestSolution = "DMA_CH1";
+LogSinkUART1.uart.uart.dmaRxChannel.$suggestSolution = "DMA_CH0";
+LogSinkUART1.uart.uart.txPin.$suggestSolution        = "boosterpack.4";

--- a/samples/freertos/ti/ble-beacon/src/hubble_ble_adv.c
+++ b/samples/freertos/ti/ble-beacon/src/hubble_ble_adv.c
@@ -100,7 +100,7 @@ static void hubble_ble_adv_update(void *arg)
 
 	size_t len = BLE_ADV_LEN - BLE_ADV_HEADER_SIZE;
 	int status = hubble_ble_advertise_get(
-		NULL, 0, &advData[HUBBLE_BLE_ADV_HEADER_SIZE], &len);
+		NULL, 0, &advData[BLE_ADV_HEADER_SIZE], &len);
 
 	if (status) {
 		Log_printf(LogModule_Beacon, Log_ERROR,
@@ -147,7 +147,6 @@ bStatus_t hubble_ble_adv_start(void)
 {
 	bStatus_t status = SUCCESS;
 	size_t len;
-	uint8_t *data;
 
 	if (_adv_timer_setup() == FAILURE) {
 		Log_printf(LogModule_Beacon, Log_ERROR,
@@ -156,14 +155,13 @@ bStatus_t hubble_ble_adv_start(void)
 	}
 
 	len = BLE_ADV_LEN - BLE_ADV_HEADER_SIZE;
-	if (hubble_ble_advertise_get(
-		    NULL, 0, &advData[HUBBLE_BLE_ADV_HEADER_SIZE], &len) != 0) {
+	if (hubble_ble_advertise_get(NULL, 0, &advData[BLE_ADV_HEADER_SIZE],
+				     &len) != 0) {
 		Log_printf(LogModule_Beacon, Log_ERROR,
 			   "Failed to get advertise data");
 		return (FAILURE);
 	}
 
-	memcpy(&advData[HUBBLE_BLE_ADV_HEADER_SIZE], data, len);
 	advData[4] = len + 1; /* output len + BLE service data type */
 
 	status = BLEAppUtil_initAdvSet(&bleAdvHandle, &hubbleInitAdvSet);

--- a/samples/freertos/ti/ble-beacon/src/hubble_ble_adv.c
+++ b/samples/freertos/ti/ble-beacon/src/hubble_ble_adv.c
@@ -9,6 +9,7 @@
 #include "ti/drivers/dpl/ClockP.h"
 #include "ti/drivers/dpl/SemaphoreP.h"
 #include "ti/drivers/dpl/TaskP.h"
+#include <ti/log/Log.h>
 
 #include <hubble/ble.h>
 
@@ -102,20 +103,28 @@ static void hubble_ble_adv_update(void *arg)
 		NULL, 0, &advData[HUBBLE_BLE_ADV_HEADER_SIZE], &len);
 
 	if (status) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to get advertise data, err: %d", status);
 		return;
 	}
 
 	advData[4] = len + 1; /* output len + BLE service data type */
 
 	if (BLEAppUtil_advStop(bleAdvHandle) != SUCCESS) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to stop advertising");
 		return;
 	}
 
 	if (BLEAppUtil_initAdvSet(&bleAdvHandle, &hubbleInitAdvSet) != SUCCESS) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to initialize advertising set");
 		return;
 	}
 
 	(void)BLEAppUtil_advStart(bleAdvHandle, &hubbleStartAdvSet);
+
+	Log_printf(LogModule_Beacon, Log_INFO, "Advertise data updated");
 }
 
 static void hubble_adv_entry(void *arg)
@@ -127,6 +136,8 @@ static void hubble_adv_entry(void *arg)
 		if (BLEAppUtil_invokeFunction(
 			    (InvokeFromBLEAppUtilContext_t)hubble_ble_adv_update,
 			    NULL) != SUCCESS) {
+			Log_printf(LogModule_Beacon, Log_ERROR,
+				   "Failed to invoke BLEAppUtil function");
 			break;
 		}
 	}
@@ -139,12 +150,16 @@ bStatus_t hubble_ble_adv_start(void)
 	uint8_t *data;
 
 	if (_adv_timer_setup() == FAILURE) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to setup advertisement timer");
 		return (FAILURE);
 	}
 
 	len = BLE_ADV_LEN - BLE_ADV_HEADER_SIZE;
 	if (hubble_ble_advertise_get(
 		    NULL, 0, &advData[HUBBLE_BLE_ADV_HEADER_SIZE], &len) != 0) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to get advertise data");
 		return (FAILURE);
 	}
 
@@ -153,20 +168,28 @@ bStatus_t hubble_ble_adv_start(void)
 
 	status = BLEAppUtil_initAdvSet(&bleAdvHandle, &hubbleInitAdvSet);
 	if (status != SUCCESS) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to initialize advertising set");
 		return (status);
 	}
 
 	status = BLEAppUtil_advStart(bleAdvHandle, &hubbleStartAdvSet);
 	if (status != SUCCESS) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to start advertising");
 		return (status);
 	}
 
 	taskHandle = TaskP_construct(&taskStruct, hubble_adv_entry, &taskParams);
 	if (taskHandle == NULL) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to construct task");
 		return (FAILURE);
 	}
 
 	ClockP_start(clockHandle);
+
+	Log_printf(LogModule_Beacon, Log_INFO, "Advertising started");
 
 	return (status);
 }

--- a/samples/freertos/ti/ble-beacon/src/hubble_ble_ti.c
+++ b/samples/freertos/ti/ble-beacon/src/hubble_ble_ti.c
@@ -10,6 +10,7 @@
 #include <ti/drivers/AESCMAC.h>
 #include <ti/drivers/AESCTR.h>
 #include <ti/drivers/cryptoutils/cryptokey/CryptoKeyPlaintext.h>
+#include <ti/log/Log.h>
 
 #include <hubble/ble.h>
 #include <hubble/port/sys.h>
@@ -41,7 +42,8 @@ int hubble_crypto_cmac(const uint8_t key[CONFIG_HUBBLE_KEY_SIZE],
 
 	handle = AESCMAC_open(AESCMAC_INSTANCE, &params);
 	if (handle == NULL) {
-		/* TODO: Log errror here */
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to open AESCMAC instance");
 		return -1;
 	}
 
@@ -80,6 +82,8 @@ int hubble_crypto_aes_ctr(const uint8_t key[CONFIG_HUBBLE_KEY_SIZE],
 
 	handle = AESCTR_open(AESCTR_INSTANCE, NULL);
 	if (handle == NULL) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to open AESCTR instance");
 		return -1;
 	}
 

--- a/samples/freertos/ti/ble-beacon/src/main.c
+++ b/samples/freertos/ti/ble-beacon/src/main.c
@@ -9,6 +9,7 @@
 
 #include <ti/drivers/Power.h>
 #include <ti/devices/DeviceFamily.h>
+#include <ti/log/Log.h>
 
 #include "ti_ble_config.h"
 #include "ti/ble/stack_util/icall/app/icall.h"
@@ -59,13 +60,21 @@ void App_StackInitDoneHandler(gapDeviceInitDoneEvent_t *deviceInitDoneData)
 
 	err = hubble_init(unix_time, master_key);
 	if (err != 0) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to initialize Hubble, err: %d", err);
 		return;
 	}
 
 	status = hubble_ble_adv_start();
 	if (status != SUCCESS) {
+		Log_printf(LogModule_Beacon, Log_ERROR,
+			   "Failed to start BLE advertising, err: %d", status);
+
 		/* TODO: Call Error Handler */
+		return;
 	}
+
+	Log_printf(LogModule_Beacon, Log_INFO, "Hubble Beacon Started");
 }
 
 int main()


### PR DESCRIPTION
- Fix packet shifted over by 6 bytes because `HUBBLE_BLE_ADV_HEADER_SIZE` instead of `BLE_ADV_HEADER_SIZE`.
- Adding TI log over UART module. Log looks like this:

```
/dev/tty.usbmodemLS470FPO1 |  0.043792000 | LogMod_LogModule_Beacon | Log_INFO    | src/hubble_ble_adv.c:190 | Advertising started
/dev/tty.usbmodemLS470FPO1 |  0.043792000 | LogMod_LogModule_Beacon | Log_INFO    | src/main.c:77            | Hubble Beacon Started
/dev/tty.usbmodemLS470FPO1 |  0.052640000 | LogMod_LogModule_Beacon | Log_INFO    | src/hubble_ble_adv.c:127 | Advertise data updated
```