### PR TITLE
port: ti: Add integration with Sysconfig

### DIFF
--- a/.meta/Hubble.component.js
+++ b/.meta/Hubble.component.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use strict";
+
+let topModules;
+
+const displayName = "Hubble Network SDK";
+const description = "Hubble Network SDK Options";
+
+topModules = [
+    {
+        displayName: displayName,
+        description: description,
+        modules: [
+            "/Hubble",
+        ]
+    }
+];
+
+let templates = [
+    {
+        "name": "/hubble_sdk_sources.c.xdt",
+        "outputPath": "HubbleSDKSources.c",
+        "alwaysRun": true
+    },
+];
+
+exports = {
+    displayName: displayName,
+    topModules: topModules,
+    templates: templates
+};

--- a/.meta/Hubble.syscfg.js
+++ b/.meta/Hubble.syscfg.js
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use strict";
+
+const topModuleDisplayName = "Hubble Network SDK";
+const topModuleDescription = "Hubble Network SDK Configuration";
+
+function validate(mod, validation)
+{
+    //TODO
+}
+
+var sdkFiles = [
+    "src/hubble.c",
+    "src/hubble_crypto.c",
+    "port/freertos/hubble_freertos.c"
+];
+
+var sdkSatFiles = [
+    "port/freertos/hubble_sat_freertos.c",
+    "src/hubble_sat.c",
+    "src/hubble_sat_packet.c",
+    "src/hubble_sat_ephemeris.c",
+    "src/reed_solomon_encoder.c",
+    "src/utils/bitarray.c"
+];
+
+var sdkBleFiles = [
+    "src/hubble_ble.c"
+];
+
+function getSDKRootDir()
+{
+    const product = system.getProducts().find(p => p.name == "Hubble Network SDK");
+    if (product) {
+        let sdkPath = system.utils.path.parse(
+            system.utils.path.parse(product.path).dir
+        ).dir;
+
+        sdkPath = system.utils.path.resolve(sdkPath).replaceAll("\\", "/");
+        return `${sdkPath}`;
+    }
+
+    return "";
+}
+
+function getOpts(mod) {
+    const result = [];
+
+    const sysconfig_products = ["simplelink_lowpower_f3_sdk", "SIMPLELINK_LOWPOWER_F3_TEST_SDK"];
+    let sdkPath = undefined;
+    for(let i = 0; i < sysconfig_products.length; i++) {
+        sdkPath = system.getProducts().find(p => p.name === sysconfig_products[i]);
+        if(sdkPath !== undefined) {
+            // WARNING using system.utils.path.posix breaks the paths on windows
+            sdkPath = system.utils.path.parse(system.utils.path.parse(sdkPath.path).dir).dir;
+            sdkPath = system.utils.path.resolve(sdkPath).replaceAll('\\','/');
+            break;
+        }
+    }
+
+    let hubble = system.modules["/Hubble"].$static;
+
+    if (hubble.useSatellite) {
+        result.push(`-DCONFIG_HUBBLE_SAT_NETWORK`);
+        result.push(`-DCONFIG_HUBBLE_SAT_NETWORK_DEVICE_TDR=${hubble.deviceTDR}`);
+    }
+
+    if (hubble.useTerrestrial) {
+        result.push(`-DCONFIG_HUBBLE_BLE_NETWORK`);
+    }
+
+    const keySize = hubble.keySize;
+    if (keySize === "128") {
+        result.push(`-DCONFIG_HUBBLE_NETWORK_KEY_128`);
+        result.push(`-DCONFIG_HUBBLE_KEY_SIZE=16`);
+    } else if (keySize === "256") {
+        result.push(`-DCONFIG_HUBBLE_NETWORK_KEY_256`);
+        result.push(`-DCONFIG_HUBBLE_KEY_SIZE=32`);
+    }
+
+    const eidRotationPeriod = hubble.eidRotationPeriod;
+    result.push(`-DCONFIG_HUBBLE_EID_ROTATION_PERIOD_SEC=${eidRotationPeriod}`);
+
+    const counterSource = hubble.counterSource;
+    if (counterSource == "unix-time") {
+        result.push(`-DCONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME`);
+    } else if (counterSource == "device-uptime") {
+        result.push(`-DCONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME`);
+    }
+
+    if (hubble.enforceNonceCheck) {
+        result.push(`-DCONFIG_HUBBLE_NETWORK_SECURITY_ENFORCE_NONCE_CHECK`);
+    }
+
+    if (hubble.useCustomNonceSequence) {
+        result.push(`-DCONFIG_HUBBLE_NETWORK_SEQUENCE_NONCE_CUSTOM`);
+    }
+
+    if (hubble.useCustomUptime) {
+        result.push(`-DCONFIG_HUBBLE_UPTIME_CUSTOM`);
+    }
+
+    const crypto = hubble.crypto;
+    if (crypto == "custom") {
+        result.push(`-DCONFIG_HUBBLE_NETWORK_CRYPTO_CUSTOM`);
+    } else if (crypto == "psa") {
+        result.push(`-DCONFIG_HUBBLE_NETWORK_CRYPTO_PSA`);
+    } else if (crypto == "mbedtls") {
+        result.push(`-DCONFIG_HUBBLE_NETWORK_CRYPTO_MBEDTLS`);
+    }
+
+    result.push(`-I${getSDKRootDir()}/src/`);
+    result.push(`-I${getSDKRootDir()}/include/`);
+    result.push(`-I${getSDKRootDir()}/port/freertos/`);
+
+    return result;
+}
+
+function getSDKFiles()
+{
+    let hubble = system.modules["/Hubble"].$static;
+    let sdkPath = getSDKRootDir();
+    let files = [...sdkFiles];
+
+    // Sat
+    if (hubble.useSatellite) {
+        files.push(...sdkSatFiles);
+    }
+
+    // Terrestrial
+    if (hubble.useTerrestrial) {
+        files.push(...sdkBleFiles);
+    }
+
+    return files.map(f => `${sdkPath}/${f}`)
+}
+
+let base = {
+    staticOnly: true,
+    displayName: "HubbleNetwork",
+    moduleStatic: {
+        name: "HubbleNetworkSDK",
+        validate: validate,
+        config: [
+            {
+                name: "useSatellite",
+                displayName: "Enable Hubble Satellite Network",
+                description: `Enable or disable Hubble Satellite Network`,
+                longDescription: `
+When set to false, Hubble Satellite Network is disabled and not available.`,
+                default: false
+
+            },
+            {
+                name: "useTerrestrial",
+                displayName: "Enable Hubble Terrestrial Network",
+                description: `Enable or disable Hubble Terrestrial Network`,
+                longDescription: `
+When set to false, Hubble Terrestrial Network is disabled and not available.`,
+                default: true
+
+            },
+            {
+                name: "deviceTDR",
+                displayName: "Device time drift retry rate in PPM",
+                longDescription: `
+Compensates for clock drift by adding retransmission
+retries proportional to time elapsed since the last
+time sync. Value is in parts per million (PPM).
+
+Higher values add more retries for the same drift,
+increasing reliability but also power consumption.
+Default of 500 PPM is suitable for typical crystal
+oscillators.
+`,
+                default: 500
+
+            },
+            {
+                name: "eidRotationPeriod",
+                displayName: "EID rotation period",
+                description: `EID rotation period in seconds`,
+                default: 86400
+            },
+            {
+                name: "counterSource",
+                displayName: "Counter source",
+                description: "Counter source",
+                longDescription: `
+Selects how the SDK computes the time counter used for
+EID rotation and key derivation.
+`,
+                default: "unix-time",
+                options: [
+                    {
+                        name: "unix-time",
+                        displayName: "Unix time counter source"
+                    },
+                    {
+                        name: "device-uptime",
+                        displayName: "Device uptime counter source"
+                    }
+                ],
+            },
+            {
+                name: "keySize",
+                displayName: "Key size - 128 or 256",
+                default: "128",
+                options: [
+                    {
+                        name: "128",
+                        displayName: "128 bits key"
+                    },
+                    {
+                        name: "256",
+                        displayName: "256 bits key"
+                    }
+                ],
+            },
+            {
+                name: "crypto",
+                displayName: "Cryptographic implementation to use",
+                default: "custom",
+                options: [
+                    {
+                        name: "custom",
+                        displayName: "Custom crypto implementation",
+                        description: `
+Provide a custom cryptographic backend. The application
+must implement all functions declared in
+<hubble/port/crypto.h>
+`,
+                    },
+                    {
+                        name: "psa",
+                        displayName: "Use PSA Crypto",
+                        description: `
+Use the PSA Crypto API for AES-CTR and CMAC. This is
+the recommended backend for Zephyr and nRF platforms.
+When building with TF-M, cryptographic operations are
+delegated to the secure processing environment.
+`,
+                    },
+                    {
+                        name: "mbedtls",
+                        displayName: "Use MbedTLS",
+                        description: `
+Use the MbedTLS library directly for AES-CTR and CMAC.
+`,
+                    }
+                ],
+            },
+            {
+                name: "enforceNonceCheck",
+                displayName: "Enforce check in nonce used in cryptography",
+                description: `
+Validates that the encryption nonce is unique before
+encrypting. Prevents nonce reuse, which would compromise
+AES-CTR confidentiality.
+
+Enabled by default. Disabling removes the runtime check
+but risks catastrophic security failure if nonces are
+ever repeated. Only disable for testing or when the
+application guarantees uniqueness by other means.
+`,
+                default: true
+            },
+            {
+                name: "useCustomNonceSequence",
+                displayName: "Application-defined sequence counter",
+                description: `
+Override the default auto-incrementing sequence counter
+with an application-provided implementation. Useful for
+deterministic testing or persisting counters across
+reboots.
+`,
+                default: false
+            },
+            {
+                name: "useCustomUptime",
+                displayName: "Application-defined uptime implementation",
+                description: `
+Override the default platform uptime function with an
+application-provided implementation. Primarily useful
+for unit testing where controlled time values are
+needed to verify time-dependent behavior.
+`,
+                default: false
+            },
+        ]
+    },
+    templates: {
+        "/ti/utils/build/GenOpts.opt.xdt": {
+            modName: "/Hubble",
+            getOpts: getOpts
+        }
+    },
+    getSDKFiles: getSDKFiles,
+}
+
+/* export the module */
+exports = base;

--- a/.meta/hubble_sdk_sources.c.xdt
+++ b/.meta/hubble_sdk_sources.c.xdt
@@ -1,0 +1,26 @@
+%%{
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ *  ======== hubble_sdk_sources.c.xdt ========
+ */
+
+    let hubble = system.modules["/Hubble"].$static;
+%%}
+
+% let keys = Object.keys(system.modules).sort();
+% /* loop over all modules in the current configuration */
+% for (let i = 0; i < keys.length; i++) {
+%     let mod = system.modules[keys[i]];
+%     if (mod.getSDKFiles) {
+/* C files contributed by `keys[i]` */
+%         let files = mod.getSDKFiles();
+%         for (let index in files) {
+#include <`files[index]`>
+%         }
+%     }
+% }

--- a/.metadata/product.json
+++ b/.metadata/product.json
@@ -1,0 +1,20 @@
+{
+    "name": "Hubble Network SDK",
+    "version": "2.0.0",
+    "displayName": "Hubble SDK",
+    "includePaths": [
+        "../"
+    ],
+    "components": [
+        "/Hubble.component.js"
+    ],
+    "devices": [
+        "CC2[37].*"
+    ],
+    "rtos": [
+        "freertos",
+        "none",
+        "nortos"
+    ],
+    "minToolVersion": "1.26.3"
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,9 @@ Using Hubble Network SDK
    * - FreeRTOS
      - :ref:`freertos_quick_start`
      - FreeRTOS support with user-managed build integration.
+   * - TI SIMPLELINK / SysConfig
+     - :ref:`ti_quick_start`
+     - TI SimpleLink SDK + SysConfig integration.
 
 Additional Resources
 ********************

--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -10,5 +10,6 @@ Quick Start
 
    zephyr/index
    freertos/index
+   ti/index
 
 

--- a/docs/quickstart/ti/index.rst
+++ b/docs/quickstart/ti/index.rst
@@ -1,0 +1,144 @@
+.. _ti_quick_start:
+
+TI SDK Quick Start (SysConfig)
+==============================
+
+This guide explains how to integrate the Hubble Network SDK into a
+`SimpleLink Low Power F3 SDK <https://www.ti.com/tool/SIMPLELINK-LOWPOWER-F3-SDK>`_
+project using `SysConfig <https://www.ti.com/tool/SYSCONFIG>`_. SysConfig
+generates driver and peripheral initialization code from a ``.syscfg`` script,
+and the Hubble Network SDK provides its own SysConfig product so its module
+can be configured alongside the TI SDK drivers in the same script.
+
+.. note::
+
+   SysConfig is the recommended integration path for TI SDK projects. If you
+   prefer to manage Hubble Network SDK build manually or are working in an
+   environment without SysConfig, follow the generic
+   :ref:`freertos_quick_start` instead — it describes how to include the SDK
+   sources and flags directly via the provided Makefile fragment.
+
+Prerequisites
+*************
+
+- `SimpleLink Low Power F3 SDK <https://www.ti.com/tool/SIMPLELINK-LOWPOWER-F3-SDK>`_ installed.
+- `TI ARM LLVM Compiler <https://www.ti.com/tool/CCSTUDIO>`_ installed.
+- SysConfig CLI tool (``sysconfig_cli.sh`` / ``sysconfig_cli.bat``) available.
+- The Hubble Network SDK cloned or added as a submodule.
+
+Set the following environment variables before building:
+
+.. code-block:: bash
+
+   export TICLANG_ARMCOMPILER=/path/to/ti-cgt-armllvm
+   export SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR=/path/to/simplelink_lowpower_f3_sdk
+   export SYSCONFIG_TOOL=/path/to/sysconfig_cli.sh
+   export HUBBLE_NETWORK_SDK=/path/to/hubble-device-sdk
+
+
+Adding the Hubble Network SDK SysConfig Product
+***********************************************
+
+The Hubble Network SDK ships a SysConfig product descriptor at
+``.metadata/product.json``. Pass it to the SysConfig CLI alongside the TI SDK
+product so both products are available in the same ``.syscfg`` script:
+
+.. code-block:: Makefile
+
+   SYSCFG_CMD_STUB = $(SYSCONFIG_TOOL) --compiler ticlang \
+       --product $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/.metadata/product.json \
+       -s $(HUBBLE_NETWORK_SDK)/.metadata/product.json
+
+Generate the configuration files into your build directory:
+
+.. code-block:: Makefile
+
+   SYSCFG_FILES := $(shell $(SYSCFG_CMD_STUB) \
+       --listGeneratedFiles --listReferencedFiles \
+       --output $(BUILD_DIR) your-app.syscfg)
+
+   SYSCFG_C_FILES   = $(filter %.c,$(SYSCFG_FILES))
+   SYSCFG_H_FILES   = $(filter %.h,$(SYSCFG_FILES))
+   SYSCFG_OPT_FILES = $(filter %.opt,$(SYSCFG_FILES))
+
+
+Configuring the Hubble Module in a ``.syscfg`` Script
+******************************************************
+
+Load the Hubble module in your ``.syscfg`` script with:
+
+.. code-block:: javascript
+
+   var hubble = scripting.addModule("/Hubble");
+
+This is all that is required. The module registers the Hubble Network SDK
+sources and include paths with the SysConfig framework so the generated
+``.opt`` files carry the right compiler flags.
+
+A minimal ``.syscfg`` script for a BLE application on CC23xx looks like:
+
+.. code-block:: javascript
+
+   // @cliArgs --board /ti/boards/LP_EM_CC2340R5 --rtos freertos
+
+   /* TI drivers */
+   var AESCCM = scripting.addModule("/ti/drivers/AESCCM");
+   AESCCM.addInstance().$name = "CONFIG_AESCCM0";
+
+   var RCL   = scripting.addModule("/ti/drivers/RCL");
+   var Power = scripting.addModule("/ti/drivers/Power");
+
+   /* Hubble Network SDK */
+   var hubble = scripting.addModule("/Hubble");
+
+   /* BLE stack and FreeRTOS */
+   var ble      = scripting.addModule("/ti/ble/ble");
+   ble.basicBLE = true;
+
+   const FreeRTOS = scripting.addModule("/freertos/FreeRTOS");
+   FreeRTOS.heapSize = 0x00004D50;
+
+
+Using Code Composer Studio (CCS)
+*********************************
+
+If you are using `Code Composer Studio <https://www.ti.com/tool/CCSTUDIO>`_
+and prefer not to write a Makefile manually, you can add the Hubble Network SDK
+SysConfig product directly from the IDE:
+
+1. Right-click the project folder in the **Project Explorer** and select
+   **Properties**.
+2. Navigate to **General** → **SysConfig**.
+3. In the **SysConfig Flags** field, append the following flag:
+
+   .. code-block:: none
+
+      -s "/path/to/hubble-device-sdk/.metadata/product.json"
+
+   Replace ``/path/to/hubble-device-sdk`` with the actual path to your Hubble
+   Network SDK checkout.
+
+4. Click **Apply and Close**. CCS will pass this flag to the SysConfig CLI
+   during the build, making the ``/Hubble`` module available in your
+   ``.syscfg`` script just as described in the section above.
+
+
+Building the Application
+************************
+
+Run SysConfig to generate the configuration files and then build:
+
+.. code-block:: bash
+
+   make -f Makefile
+
+The ``Makefile`` must pass the generated ``.opt`` files to the
+compiler using the ``@`` prefix so that SysConfig-generated flags (include
+paths, preprocessor definitions) are applied:
+
+.. code-block:: Makefile
+
+   CFLAGS += $(addprefix @,$(SYSCFG_OPT_FILES))
+
+
+See the ``samples/freertos/ti/ble_beacon`` sample for a complete working example.

--- a/port/freertos/hubble_sat_freertos.c
+++ b/port/freertos/hubble_sat_freertos.c
@@ -24,7 +24,7 @@
 
 #define MSEC_PER_SEC 1000U
 
-static SemaphoreHandle_t _transmit_sem;
+static SemaphoreHandle_t _sat_freertos_sem;
 
 static inline int16_t _time_offset_get_ms(void)
 {
@@ -45,7 +45,7 @@ int hubble_sat_port_packet_send(const struct hubble_sat_packet *packet,
 	int ret;
 
 	/* TODO: Should we add a parameter in the API instead of wait forever? */
-	xSemaphoreTake(_transmit_sem, portMAX_DELAY);
+	xSemaphoreTake(_sat_freertos_sem, portMAX_DELAY);
 
 	ret = hubble_sat_board_enable();
 	if (ret != 0) {
@@ -82,20 +82,20 @@ end:
 	}
 
 enable_error:
-	(void)xSemaphoreGive(_transmit_sem);
+	(void)xSemaphoreGive(_sat_freertos_sem);
 	return ret;
 }
 
 int hubble_sat_port_init(void)
 {
-	_transmit_sem = xSemaphoreCreateBinary();
-	if (_transmit_sem == NULL) {
+	_sat_freertos_sem = xSemaphoreCreateBinary();
+	if (_sat_freertos_sem == NULL) {
 		return -ENOMEM;
 	}
 
-	if (xSemaphoreGive(_transmit_sem) != pdTRUE) {
-		vSemaphoreDelete(_transmit_sem);
-		_transmit_sem = NULL;
+	if (xSemaphoreGive(_sat_freertos_sem) != pdTRUE) {
+		vSemaphoreDelete(_sat_freertos_sem);
+		_sat_freertos_sem = NULL;
 		return -EAGAIN;
 	}
 

--- a/samples/freertos/ti/ble-beacon/README.md
+++ b/samples/freertos/ti/ble-beacon/README.md
@@ -51,6 +51,12 @@ export SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR=/Applications/ti/simplelink_lowpow
 export SYSCONFIG_TOOL=/Applications/ti/sysconfig_1.23.2/sysconfig_cli.sh
 ```
 
+   When using the SysConfig-based build (*makefile-syscfg*), also set *HUBBLE_NETWORK_SDK* to the
+   root of this SDK (defaults to four directories above the sample if unset):
+```bash
+export HUBBLE_NETWORK_SDK=/path/to/hubblenetwork-sdk
+```
+
 2. **Embed Key and Unix Time**
 
    Use the *embed_key_time.py* script to provision a BLE key and Unix timestamp:
@@ -67,6 +73,13 @@ python ../../../../tools/embed_key_time.py --base64 <path-to-key> -o src/
 
 ```bash
 make
+```
+
+   Alternatively, use the SysConfig-based build (*makefile-syscfg*), which generates driver and
+   peripheral configuration via SysConfig using both the TI SDK and Hubble Network SDK products:
+
+```bash
+make -f makefile-syscfg
 ```
 
 4. **Flash the Firmware**
@@ -95,3 +108,5 @@ Once the firmware is flashed:
 + **src/hubble_ble_adv.c**: BLE advertising implementation.
 + **src/hubble_ble_ti.c**: This is a core file to integrate with HubbleNetwork SDK. It implements the required cryptograhic API.
 + **makefile**: Build system for the project.
++ **makefile-syscfg**: SysConfig-based build system; generates driver configuration using both the TI SDK and Hubble Network SDK SysConfig products.
++ **ble-beacon-hubble.syscfg**: SysConfig script that configures drivers, BLE stack, FreeRTOS, and the Hubble Network SDK module.

--- a/samples/freertos/ti/ble-beacon/ble-beacon-hubble.syscfg
+++ b/samples/freertos/ti/ble-beacon/ble-beacon-hubble.syscfg
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2018, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+// @cliArgs --board /ti/boards/LP_EM_CC2340R5 --rtos freertos
+
+/*
+ *  ble-beacon-hubble.syscfg
+ */
+
+const lpName = system.getScript("/ti/ble/ble_common.js").getBoardOrLaunchPadName(true);
+
+/* ======== AESCCM ======== */
+var AESCCM = scripting.addModule("/ti/drivers/AESCCM");
+var aesccm = AESCCM.addInstance();
+aesccm.$name = "CONFIG_AESCCM0";
+
+/* ======== AESECB ======== */
+var AESECB = scripting.addModule("/ti/drivers/AESECB");
+var aesecb = AESECB.addInstance();
+aesecb.$name = "CONFIG_AESECB0";
+
+/* ======== AESCMAC ======== */
+var AESCMAC = scripting.addModule("/ti/drivers/AESCMAC");
+var aescmac = AESCMAC.addInstance();
+aescmac.$name = "CONFIG_AESCMAC0";
+
+/* ======== AESCTR ======== */
+var AESCTR = scripting.addModule("/ti/drivers/AESCTR");
+var aescmac = AESCTR.addInstance();
+aescmac.$name = "CONFIG_AESCTR0";
+
+/* ======== ECDH ======== */
+var ECDH = scripting.addModule("/ti/drivers/ECDH");
+var ecdh = ECDH.addInstance();
+ecdh.$name = "CONFIG_ECDH0"
+
+/* ======== NVS ======== */
+var NVS = scripting.addModule("/ti/drivers/NVS");
+var nvs = NVS.addInstance();
+nvs.internalFlash.regionBase   = 0x7D000;
+if(lpName == "LP_EM_CC2745R10_Q1")
+{
+    nvs.internalFlash.regionBase   = 0xE5000;
+}
+nvs.internalFlash.regionSize   = 0x3000;
+nvs.$name = "CONFIG_NVSINTERNAL";
+
+/* ======== RCL ======== */
+const RCL = scripting.addModule("/ti/drivers/RCL");
+
+/* ======== POWER ======== */
+var Power = scripting.addModule("/ti/drivers/Power");
+
+/* Hubble */
+var hubble = scripting.addModule("/Hubble");
+
+/* ======== RNG ======== */
+var RNG = scripting.addModule("/ti/drivers/RNG");
+var rng = RNG.addInstance();
+
+/* ======== RF Design ======== */
+var rfDesign = scripting.addModule("ti/devices/radioconfig/rfdesign");
+const rfDesignSettings = system.getScript("/ti/common/lprf_rf_design_settings.js").rfDesignSettings;
+for(var setting in rfDesignSettings)
+{
+    rfDesign[setting] = rfDesignSettings[setting];
+}
+
+const radioSettings = system.getScript("/ti/ble/ble_common.js").getRadioScript(rfDesign.rfDesign,system.deviceData.deviceId);
+const bleRfDesignSettings = radioSettings.rfDesignParams;
+for(var setting in bleRfDesignSettings)
+{
+    rfDesign[setting] = bleRfDesignSettings[setting];
+}
+
+/* ======== Device ======== */
+var device = scripting.addModule("ti/devices/CCFG");
+const ccfgSettings = system.getScript("/ti/common/lprf_ccfg_settings.js").ccfgSettings;
+for(var setting in ccfgSettings)
+{
+    device[setting] = ccfgSettings[setting];
+}
+
+/* ======== FreeRTOS ======== */
+const FreeRTOS    = scripting.addModule("/freertos/FreeRTOS");
+const Settings    = scripting.addModule("/ti/posix/freertos/Settings");
+
+FreeRTOS.heapSize         = 0x00004D50;
+
+if (lpName.match(/CC27\d\d/))
+{
+    FreeRTOS.heapSize         = 0x00010000;
+}
+if (lpName == "LP_EM_CC2340R53")
+{
+    FreeRTOS.heapSize         = 0x0000A000;
+}
+
+FreeRTOS.timerStackSize       = 0x00000190;
+FreeRTOS.idleStackSize        = 0x00000130;
+
+/* ======== BLE ======== */
+var ble = scripting.addModule("/ti/ble/ble");
+ble.basicBLE = true;
+
+/* ======== RNG ======== */
+var RNG = scripting.addModule("/ti/drivers/RNG");
+RNG.rngReturnBehavior = "RNG_RETURN_BEHAVIOR_BLOCKING";
+
+/**
+ * Import log module used in this configuration.
+ */
+const LogModule    = scripting.addModule("/ti/log/LogModule", {}, false);
+const LogModule1   = LogModule.addInstance();
+const LogSinkUART  = scripting.addModule("/ti/log/LogSinkUART", {}, false);
+const LogSinkUART1 = LogSinkUART.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+LogModule1.$name      = "LogModule_Beacon";
+LogModule1.loggerSink = "/ti/log/LogSinkUART";
+
+LogSinkUART1.$name          = "CONFIG_ti_log_LogSinkUART_0";
+LogModule1.logger           = LogSinkUART1;
+LogSinkUART1.uart.$name     = "CONFIG_UART2_0";
+LogSinkUART1.uart.$hardware = system.deviceData.board.components.XDS110UART;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+LogSinkUART1.uart.uart.$suggestSolution              = "UART0";
+LogSinkUART1.uart.uart.dmaTxChannel.$suggestSolution = "DMA_CH1";
+LogSinkUART1.uart.uart.dmaRxChannel.$suggestSolution = "DMA_CH0";
+LogSinkUART1.uart.uart.txPin.$suggestSolution        = "boosterpack.4";

--- a/samples/freertos/ti/ble-beacon/makefile-syscfg
+++ b/samples/freertos/ti/ble-beacon/makefile-syscfg
@@ -1,0 +1,223 @@
+SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR ?= $(abspath ../../../../../../..)
+HUBBLE_NETWORK_SDK ?= $(abspath ../../../../)
+NAME = ble-beacon
+
+# Build directory for all artifacts
+BUILD_DIR ?= build
+
+include $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/imports.mak
+
+CC = "$(TICLANG_ARMCOMPILER)/bin/tiarmclang"
+LNK = "$(TICLANG_ARMCOMPILER)/bin/tiarmclang"
+
+SYSCONFIG_GUI_TOOL = $(dir $(SYSCONFIG_TOOL))sysconfig_gui$(suffix $(SYSCONFIG_TOOL))
+SYSCFG_CMD_STUB = $(SYSCONFIG_TOOL) --compiler ticlang -s $(HUBBLE_NETWORK_SDK)/.metadata/product.json \
+		  --product $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/.metadata/product.json
+SYSCFG_GUI_CMD_STUB = $(SYSCONFIG_GUI_TOOL) --compiler ticlang -s $(HUBBLE_NETWORK_SDK)/.metadata/product.json \
+		      --product $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/.metadata/product.json
+SYSCFG_FILES := $(shell $(SYSCFG_CMD_STUB) --listGeneratedFiles --listReferencedFiles --output $(BUILD_DIR) ble-beacon-hubble.syscfg)
+
+SYSCFG_C_FILES = $(filter %.c,$(SYSCFG_FILES))
+SYSCFG_H_FILES = $(filter %.h,$(SYSCFG_FILES))
+SYSCFG_OPT_FILES = $(filter %.opt,$(SYSCFG_FILES))
+
+# Enable verbose output by setting VERBOSE=1
+V := @
+ifeq ($(VERBOSE), 1)
+  V :=
+endif
+
+OBJECTS = $(addprefix $(BUILD_DIR)/, \
+	  app_main.obj \
+	  app_hubble_ble_adv.obj \
+	  app_hubble_ble_ti.obj \
+	  common_Services_dev_info_dev_info_service.obj \
+	  common_BLEAppUtil_bleapputil_task.obj \
+	  common_BLEAppUtil_bleapputil_init.obj \
+	  common_BLEAppUtil_bleapputil_process.obj \
+	  common_BLEAppUtil_bleapputil_stack_callbacks.obj \
+	  common_lib_opt_ctrl_opt_adv_nconn.obj \
+	  common_Startup_osal_icall_ble.obj \
+	  common_Startup_rom_init.obj \
+	  common_Drivers_NV_crc.obj \
+	  common_Drivers_NV_nvocmp.obj \
+	  common_iCall_icall.obj \
+	  common_iCall_icall_user_config.obj \
+	  common_iCall_icall_POSIX.obj \
+	  common_config_ble_user_config.obj \
+	  common_Profiles_simple_gatt_simple_gatt_profile.obj \
+	  common_BLE_SysStat_blesysstat.obj \
+	  $(patsubst %.c,%.obj,$(notdir $(SYSCFG_C_FILES))))
+
+
+CFLAGS += -I. \
+	  -I../.. \
+	  -Isrc/ \
+	  -I$(BUILD_DIR) \
+	  "-I$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source" \
+	  "-I$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti" \
+	  "-I$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/common/cc26xx" \
+	  "-I$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/posix/ticlang" \
+	  "-I$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/third_party/freertos/include" \
+	  "-I$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/third_party/freertos/portable/GCC/ARM_CM0" \
+	  "-I$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/kernel/freertos" \
+	  $(addprefix @,$(SYSCFG_OPT_FILES)) \
+	  "@$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/stack_util/config/build_components.opt" \
+	  "@$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/stack_util/config/factory_config.opt" \
+	  -DICALL_NO_APP_EVENTS \
+	  -mthumb \
+	  -mlittle-endian \
+	  -std=gnu99 \
+	  -ffunction-sections \
+	  -g \
+	  -Oz \
+	  -DCC23X0 \
+	  -DNVOCMP_NWSAMEITEM=1 \
+	  -DNVOCMP_NVPAGES=6 \
+	  -DFREERTOS \
+	  -DNVOCMP_POSIX_MUTEX \
+	  -Wunused-function \
+	  -gdwarf-3 \
+	  -mcpu=cortex-m0plus \
+	  -march=thumbv6m \
+	  -mfloat-abi=soft \
+	  -Wno-pointer-sign
+
+LFLAGS += -Wl,--diag_wrap=off \
+	  -Wl,--display_error_number \
+	  -Wl,-x \
+	  -Wl,-c \
+	  -Wl,-m,$(BUILD_DIR)/$(NAME).map \
+	  -Wl,--rom_model \
+	  -Wl,--warn_sections \
+	  -L$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source \
+	  -L$(TICLANG_ARMCOMPILER)/lib \
+	  $(BUILD_DIR)/ti_utils_build_linker.cmd.genlibs \
+	  $(BUILD_DIR)/cc2340_freertos.cmd \
+	  -llibc.a
+
+all: $(BUILD_DIR) postbuild
+
+$(BUILD_DIR):
+	@mkdir -p $(BUILD_DIR)
+	@cp cc2340_freertos.cmd $(BUILD_DIR)
+
+.PHONY: postbuild
+postbuild: $(BUILD_DIR)/$(NAME).out
+	$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/tools/common/crc_tool/crc_tool patch-image --elf $(BUILD_DIR)/$(NAME).out --symbol-prefix ti_utils_build_GenMap_sym_CRC_CCFG -o $(BUILD_DIR)/$(NAME).out
+	$(TICLANG_ARMCOMPILER)/bin/tiarmobjcopy -O ihex $(BUILD_DIR)/$(NAME).out $(BUILD_DIR)/$(NAME).hex
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_FILES): syscfg
+	@ echo generation complete
+
+syscfg: ble-beacon-hubble.syscfg $(BUILD_DIR)
+	@ echo Generating configuration files...
+	$(V) $(SYSCFG_CMD_STUB) --output $(BUILD_DIR) $<
+
+
+# Helpful hint that the user needs to use a standalone SysConfig installation
+$(SYSCONFIG_GUI_TOOL):
+	$(error $(dir $(SYSCONFIG_TOOL)) does not contain the GUI framework \
+        necessary to launch the SysConfig GUI.  Please set SYSCONFIG_TOOL \
+        (in your SDK's imports.mak) to a standalone SysConfig installation \
+        rather than one inside CCS)
+
+syscfg-gui: ble-beacon.syscfg $(SYSCONFIG_GUI_TOOL)
+	@ echo Opening SysConfig GUI
+	$(V) $(SYSCFG_GUI_CMD_STUB) $<
+
+
+define C_RULE
+$(BUILD_DIR)/$(basename $(notdir $(1))).obj: $(1) $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $$@
+	$(V) $(CC) $(CFLAGS) -c $$< -o $$@
+endef
+
+$(foreach c_file,$(SYSCFG_C_FILES),$(eval $(call C_RULE,$(c_file))))
+
+$(BUILD_DIR)/app_main.obj: src/main.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_BLE_SysStat_blesysstat.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/stack_util/health_toolkit/src/ble_sys_stat.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_Services_dev_info_dev_info_service.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/services/dev_info/src/dev_info_service.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_BLEAppUtil_bleapputil_task.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/app_util/framework/src/bleapputil_task.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_BLEAppUtil_bleapputil_init.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/app_util/framework/src/bleapputil_init.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_BLEAppUtil_bleapputil_process.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/app_util/framework/src/bleapputil_process.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_BLEAppUtil_bleapputil_stack_callbacks.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/app_util/framework/src/bleapputil_stack_callbacks.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_lib_opt_ctrl_opt_adv_nconn.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/stack_util/lib_opt/src/ctrl_opt_adv_nconn.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+
+$(BUILD_DIR)/common_Startup_osal_icall_ble.obj: src/common/Startup/osal_icall_ble.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_Startup_rom_init.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/stack_util/lib_opt/rom_init.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_Drivers_NV_crc.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/common/nv/crc.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_Drivers_NV_nvocmp.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/common/nv/nvocmp.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_iCall_icall.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/stack_util/icall/app/src/icall.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_iCall_icall_user_config.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/stack_util/icall/app/src/icall_user_config.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_config_ble_user_config.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/app_util/config/src/ble_user_config.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/app_hubble_ble_adv.obj: src/hubble_ble_adv.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/app_hubble_ble_ti.obj: src/hubble_ble_ti.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_Profiles_simple_gatt_simple_gatt_profile.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/profiles/simple_gatt/src/simple_gatt_profile.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/common_iCall_icall_POSIX.obj: $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source/ti/ble/stack_util/icall/app/src/icall_POSIX.c $(SYSCFG_H_FILES) $(BUILD_DIR)
+	@ echo Building $@
+	$(V) $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/$(NAME).out: $(OBJECTS)
+	@ echo linking $@
+	$(V) $(LNK) -Wl,-u,_c_int00 $(OBJECTS)  $(LFLAGS) -o $@
+
+clean:
+	@ echo Cleaning...
+	$(V) $(RM) -rf $(BUILD_DIR) > $(DEVNULL) 2>&1
+	$(V) $(RM) $(call SLASH_FIXUP,$(SYSCFG_FILES)) > $(DEVNULL) 2>&1


### PR DESCRIPTION
- Add integration with TI's syscfonfig tool
- Add an option to build ble-beacon using sysconfig
- Quickstart documentation for sysconfig integration.

See individual commits for more details.