### PR TITLE
sat: freertos: add DTM support for FreeRTOS

### DIFF
--- a/port/esp-idf/hubblenetwork-sdk/Kconfig
+++ b/port/esp-idf/hubblenetwork-sdk/Kconfig
@@ -49,6 +49,12 @@ config HUBBLE_SAT_NETWORK_DEVICE_TDR
 		last time the device had time synced. It is
 		represented in PPM (parts per million).
 
+config HUBBLE_SAT_NETWORK_DTM_MODE
+	bool "Enable DTM mode"
+	help
+	  Enable DTM mode in the SDK. It is intended
+	  to test the operation of radio.
+
 choice
 	prompt "Hubble Sat Network protocol"
 	default HUBBLE_SAT_NETWORK_PROTOCOL_V1

--- a/port/freertos/hubble_sat_freertos.c
+++ b/port/freertos/hubble_sat_freertos.c
@@ -101,3 +101,80 @@ int hubble_sat_port_init(void)
 
 	return hubble_sat_board_init();
 }
+
+#ifdef CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE
+
+int hubble_sat_dtm_port_packet_send(const struct hubble_sat_packet *packet,
+				    int8_t channel)
+{
+	int ret;
+	struct hubble_sat_packet_frames frames = {0};
+
+	if ((channel < -1) || (channel >= HUBBLE_SAT_NUM_CHANNELS)) {
+		return -EINVAL;
+	}
+
+	ret = hubble_sat_packet_frames_get(packet, &frames);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (channel != -1) {
+		for (uint8_t i = 0; i < HUBBLE_PACKET_FRAME_MAX_SIZE; i++) {
+			frames.frame[i].channel = channel;
+		}
+	}
+
+	ret = hubble_sat_board_enable();
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = hubble_sat_board_packet_send(&frames);
+	if (ret != 0) {
+		(void)hubble_sat_board_disable();
+		return ret;
+	}
+
+	return hubble_sat_board_disable();
+}
+
+int hubble_sat_dtm_port_power_set(int8_t power)
+{
+	return hubble_sat_board_power_set(power);
+}
+
+int hubble_sat_dtm_port_cw_start(uint8_t channel)
+{
+	int ret;
+
+	if (channel >= HUBBLE_SAT_NUM_CHANNELS) {
+		return -EINVAL;
+	}
+
+	ret = hubble_sat_board_enable();
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = hubble_sat_board_cw_start(channel);
+	if (ret != 0) {
+		(void)hubble_sat_board_disable();
+		return ret;
+	}
+
+	return 0;
+}
+
+int hubble_sat_dtm_port_cw_stop(void)
+{
+	int ret = hubble_sat_board_cw_stop();
+	if (ret != 0) {
+		(void)hubble_sat_board_disable();
+		return ret;
+	}
+
+	return hubble_sat_board_disable();
+}
+
+#endif /* CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE */

--- a/port/freertos/sat_board.h
+++ b/port/freertos/sat_board.h
@@ -78,6 +78,31 @@ int hubble_sat_board_disable(void);
  */
 int hubble_sat_board_packet_send(const struct hubble_sat_packet_frames *packet);
 
+/**
+ * @brief Set the transmit power level.
+ *
+ * @param power Desired TX power in dBm.
+ *
+ * @return 0 on success, or a negative error code if the power level is out of range.
+ */
+int hubble_sat_board_power_set(int8_t power);
+
+/**
+ * @brief Start continuous wave (CW) transmission on the specified channel.
+ *
+ * @param channel RF channel index to transmit on.
+ *
+ * @return 0 on success, or a negative error code if the channel is invalid.
+ */
+int hubble_sat_board_cw_start(uint8_t channel);
+
+/**
+ * @brief Stop continuous wave (CW) transmission.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int hubble_sat_board_cw_stop(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add DTM into FreeRTOS port.

I'm not sure how to feel about this commit since the change is identical to `hubble_sat_zephyr.c` and `zephyr/sat_board.h`, so the code is duplicated. But we need it to add dtm support to freertos.