### PR TITLE
sat: dtm: Add -1 payload mode

### DIFF
--- a/include/hubble/sat/dtm.h
+++ b/include/hubble/sat/dtm.h
@@ -30,11 +30,15 @@ extern "C" {
  * All the payload is random bytes.
  */
 enum hubble_sat_dtm_packet_type {
+	HUBBLE_SAT_DTM_PACKET_SINGLE_FRAME,
 	HUBBLE_SAT_DTM_PACKET_0,
 	HUBBLE_SAT_DTM_PACKET_4,
 	HUBBLE_SAT_DTM_PACKET_9,
 	HUBBLE_SAT_DTM_PACKET_13,
 };
+
+/* @brief Flag to indicate 'payload -1' mode, where only the first frame is transmitted */
+#define HUBBLE_SAT_DTM_PACKET_ONE_FRAME_ONLY_LEN UINT8_MAX
 
 /**
  * @brief Send a DTM test packet.

--- a/src/hubble_sat.c
+++ b/src/hubble_sat.c
@@ -159,6 +159,10 @@ int hubble_sat_dtm_packet_send(enum hubble_sat_dtm_packet_type type,
 	uint8_t len;
 	int ret;
 
+	if (type == HUBBLE_SAT_DTM_PACKET_SINGLE_FRAME) {
+		packet.length = HUBBLE_SAT_DTM_PACKET_ONE_FRAME_ONLY_LEN;
+		goto end;
+	}
 	switch (type) {
 	case HUBBLE_SAT_DTM_PACKET_0:
 		len = 0;
@@ -184,6 +188,7 @@ int hubble_sat_dtm_packet_send(enum hubble_sat_dtm_packet_type type,
 		return ret;
 	}
 
+end:
 	ret = hubble_sat_dtm_port_packet_send(&packet, channel);
 	if (ret < 0) {
 		HUBBLE_LOG_WARNING(

--- a/src/hubble_sat_packet.c
+++ b/src/hubble_sat_packet.c
@@ -12,6 +12,10 @@
 #include <hubble/port/sat_radio.h>
 #include <hubble/port/sys.h>
 
+#ifdef CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE
+#include <hubble/sat/dtm.h>
+#endif
+
 #include "reed_solomon_encoder.h"
 #include "hubble_priv.h"
 #include "utils/bitarray.h"
@@ -392,6 +396,16 @@ int hubble_sat_packet_frames_get(const struct hubble_sat_packet *packet,
 		frames->frame[0].data[frame_pos + i] = rs_symbols[i];
 	}
 	frame_pos += HUBBLE_PHY_ECC_SYMBOLS_SIZE;
+
+#ifdef CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE
+	/* Payload -1 mode will cause an early return */
+	if (packet->length == HUBBLE_SAT_DTM_PACKET_ONE_FRAME_ONLY_LEN) {
+		frames->total_number_of_symbols =
+			HUBBLE_PACKET_FRAME_PAYLOAD_MAX_SIZE;
+		return 0;
+	}
+
+#endif /* CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE */
 
 	/* From now on, we will need to check which frame to add data since that
 	 * depends on user controlled data.


### PR DESCRIPTION
Add -1 payload mode to only send the first 16 symbols (8 preamble, 6+2 header).