### PR TITLE
fix: sat/dtm: fix channel comparison error for hopping mode

### DIFF
--- a/port/freertos/hubble_sat_freertos.c
+++ b/port/freertos/hubble_sat_freertos.c
@@ -110,7 +110,7 @@ int hubble_sat_dtm_port_packet_send(const struct hubble_sat_packet *packet,
 	int ret;
 	struct hubble_sat_packet_frames frames = {0};
 
-	if ((channel < -1) || (channel >= HUBBLE_SAT_NUM_CHANNELS)) {
+	if ((channel < -1) || (channel >= (int8_t)HUBBLE_SAT_NUM_CHANNELS)) {
 		return -EINVAL;
 	}
 

--- a/port/zephyr/hubble_sat_zephyr.c
+++ b/port/zephyr/hubble_sat_zephyr.c
@@ -92,7 +92,7 @@ int hubble_sat_dtm_port_packet_send(const struct hubble_sat_packet *packet,
 	int ret;
 	struct hubble_sat_packet_frames frames = {0};
 
-	if ((channel < -1) || (channel >= HUBBLE_SAT_NUM_CHANNELS)) {
+	if ((channel < -1) || (channel >= (int8_t)HUBBLE_SAT_NUM_CHANNELS)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
HUBBLE_SAT_NUM_CHANNELS is defined as unsigned (19U), when the channel is input as -1 (hopping mode for DTM), -1 is promoted to from int8_t to unsigned int, which failed the check.