### PR TITLE
ESP-IDF: add Satellite support for ESP32C6

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,9 @@ Using Hubble Network SDK
    * - TI SIMPLELINK / SysConfig
      - :ref:`ti_quick_start`
      - TI SimpleLink SDK + SysConfig integration.
+   * - ESP-IDF
+     - :ref:`esp_idf_quick_start`
+     - ESP-IDF support with component-based integration.
 
 Additional Resources
 ********************

--- a/docs/quickstart/esp-idf/index.rst
+++ b/docs/quickstart/esp-idf/index.rst
@@ -1,0 +1,104 @@
+.. _esp_idf_quick_start:
+
+ESP-IDF Quick Start
+===================
+
+This guide explains how to integrate the Hubble Network SDK into an
+`ESP-IDF <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html>`_
+project. The SDK ships as an ESP-IDF component that can be pulled into any
+ESP-IDF application via ``EXTRA_COMPONENT_DIRS``.
+
+
+Prerequisites
+*************
+
+- `ESP-IDF <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html>`_
+  installed and exported in the current shell (e.g. ``source ~/esp/esp-idf/export.sh``).
+- A supported ESP32 target. The BLE Network module works on any ESP32 chip
+  with a Bluetooth® Low Energy controller supported by ESP-IDF. The Satellite
+  Network module currently targets the **ESP32-C6**.
+- The Hubble Network SDK cloned or added to your project as a Git submodule.
+
+
+Adding Hubble Network to an ESP-IDF Project
+*******************************************
+
+#. Add the Hubble Network SDK to your application, for example as a submodule:
+
+   .. code-block:: bash
+
+      git submodule add https://github.com/HubbleNetwork/hubble-device-sdk
+
+#. Point your top-level ``CMakeLists.txt`` at the SDK's ESP-IDF component
+   directory using ``EXTRA_COMPONENT_DIRS``, and add ``hubblenetwork-sdk`` to
+   the component list:
+
+   .. code-block:: cmake
+
+      cmake_minimum_required(VERSION 3.13.1)
+
+      set(EXTRA_COMPONENT_DIRS path/to/hubble-device-sdk/port/esp-idf/)
+
+      set(COMPONENTS
+              "main"
+              "bt"
+              "hubblenetwork-sdk"
+      )
+
+      include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+      project(my-app LANGUAGES C)
+
+#. Enable the desired Hubble modules. Either run ``idf.py menuconfig`` and
+   toggle them under *Component config* → *Hubble*, or set them in your
+   project's ``sdkconfig.defaults``:
+
+   .. code-block:: kconfig
+
+      # Terrestrial (BLE) Network
+      CONFIG_HUBBLE_BLE_NETWORK=y
+
+      # Satellite Network
+      CONFIG_HUBBLE_SAT_NETWORK=y
+
+   When enabling the BLE Network module on ESP32 chips, you will also want the
+   standard BLE controller bits:
+
+   .. code-block:: kconfig
+
+      CONFIG_BT_ENABLED=y
+      CONFIG_BT_BLE_50_FEATURES_SUPPORTED=n
+      CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y
+
+   When enabling the Satellite Network module on ESP32-C6, you will also need to
+   include the PHY lib:
+
+   .. code-block:: kconfig
+
+      CONFIG_ESP_PHY_ENABLE_CERT_TEST=y
+
+
+Satellite Network on ESP32-C6: Required PHY Blob
+************************************************
+
+.. important::
+
+   The Satellite Network module requires a PHY library blob from Espressif
+   that is currently in Early Access (EA). The ``libphy`` shipped with ESP-IDF
+   does **not** include this API yet, so the blob must be swapped in manually
+   before building any Satellite Network application on the ESP32-C6.
+
+#. Download the Espressif PHY blob:
+
+   `libphy_C6_20260317_c83212e.zip <https://dl.espressif.com/AE/libphy_C6_20260317_c83212e%20(2).zip>`_
+
+#. Unzip the archive and copy the extracted ``*.a`` files over the matching
+   files in your ESP-IDF installation:
+
+   .. code-block:: bash
+
+      unzip "libphy_C6_20260317_c83212e.zip"
+      cp *.a $IDF_PATH/components/esp_phy/lib/esp32c6/
+
+This step is temporary. Once Espressif ships the API upstream, the SDK
+will consume it directly and the blob swap will no longer be needed.

--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -11,5 +11,6 @@ Quick Start
    zephyr/index
    freertos/index
    ti/index
+   esp-idf/index
 
 

--- a/port/esp-idf/hubblenetwork-sdk/CMakeLists.txt
+++ b/port/esp-idf/hubblenetwork-sdk/CMakeLists.txt
@@ -17,6 +17,13 @@ else()
     )
 endif()
 
+set(INC_DIRS
+    "${SDK_BASE_DIR}/include"
+    "${SDK_BASE_DIR}/src"
+    "${SDK_BASE_DIR}/port/esp-idf"
+    "${SDK_BASE_DIR}/port/freertos"
+)
+
 if(CONFIG_HUBBLE_BLE_NETWORK)
     list(APPEND SRCS
         "${SDK_BASE_DIR}/src/hubble_ble.c"
@@ -37,20 +44,29 @@ if(CONFIG_HUBBLE_SAT_NETWORK)
             "${SDK_BASE_DIR}/src/hubble_sat_packet.c"
         )
     endif()
+
+    # add board support
+    if(IDF_TARGET STREQUAL "esp32c6")
+        list(APPEND INC_DIRS
+            "${CMAKE_CURRENT_LIST_DIR}/boards/esp32c6"
+        )
+        list(APPEND SRCS
+            "${CMAKE_CURRENT_LIST_DIR}/boards/esp32c6/radio.c"
+        )
+    endif()
 endif()
 
 idf_component_register(
     INCLUDE_DIRS
-        "${SDK_BASE_DIR}/include"
-        "${SDK_BASE_DIR}/src"
-        "${SDK_BASE_DIR}/port/esp-idf"
-        "${SDK_BASE_DIR}/port/freertos"
+        ${INC_DIRS}
     PRIV_INCLUDE_DIRS
     REQUIRES
     PRIV_REQUIRES
         "mbedtls"
         "freertos"
         "log"
+        "esp_phy"
+        "esp_driver_gptimer"
     SRCS
         ${SRCS}
 )

--- a/port/esp-idf/hubblenetwork-sdk/boards/esp32c6/radio.c
+++ b/port/esp-idf/hubblenetwork-sdk/boards/esp32c6/radio.c
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Standard C Libraries */
+#include <errno.h>
+
+/* Hubble */
+#include <hubble/port/sat_radio.h>
+#include <hubble/sat/packet.h>
+
+/* FreeRTOS / ESP-IDF */
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+
+#include "driver/gptimer.h"
+#include "esp_phy_init.h"
+#include "esp_phy_cert_test.h"
+
+#include "sat_board.h"
+
+#define ESP_RADIO_OFF_DELAY_US          450U
+#define ESP_RADIO_ON_DELAY_US           70U
+#define DEFAULT_TX_POWER_DBM            20U
+#define ESP_STEP_SCALE(_step)           ((_step) * 4)
+
+/* The center frequency for channel 0 is 2482208625
+ * -> f_base = 2482208625 - (32 * 400) = 2482195825
+ * Each channel is 25.75 kHz
+ * --> offset = 25.75k / 400 ~= 64 steps (round)
+ * Base is set at 24822 MHz,
+ * (2482195825 - 2.482e9) / 400 = 489 steps
+ */
+#define HUBBLE_BASE_FREQUENCY           2482U
+#define HUBBLE_CHANNEL_OFFSET(_channel) (((_channel) * 64) + 489)
+
+/**
+ * This semaphore is used to protect a packet transmission and avoid
+ * race conditions.
+ */
+static SemaphoreHandle_t _transmit_sem;
+
+/**
+ * This semaphore is used between symbol transmissions. It allows the current
+ * thread to wait a symbol transmission without need to poll for a condition.
+ */
+static SemaphoreHandle_t _symbol_sem;
+
+/**
+ * General Purpose Timer for symbol timing.
+ */
+static gptimer_handle_t _timer_handle = NULL;
+static gptimer_config_t _timer_config = {
+	.clk_src = GPTIMER_CLK_SRC_DEFAULT, /* Select the default clock source */
+	.direction = GPTIMER_COUNT_UP,      /* Counting direction is up */
+	.resolution_hz = 1 * 1000 * 1000,   /* 1 Mhz -> 1 tick = 1 us */
+};
+
+/* Espressif PHY API */
+extern void phy_set_step_01k(bool step_01k);
+extern void phy_set_freq(uint16_t freq_mhz, int offset);
+extern void phy_tx_tone(bool txtone_en, bool bt_mode, uint8_t pwr_index);
+
+static int _esp_err_to_errno(esp_err_t status)
+{
+	int ret;
+
+	switch (status) {
+	case ESP_OK:
+		ret = 0;
+		break;
+	case ESP_FAIL:
+		ret = -EIO;
+		break;
+	case ESP_ERR_NO_MEM:
+		ret = -ENOMEM;
+		break;
+	case ESP_ERR_INVALID_ARG:
+		ret = -EINVAL;
+		break;
+	case ESP_ERR_INVALID_STATE:
+		ret = -EPERM;
+		break;
+	case ESP_ERR_INVALID_SIZE:
+		ret = -EINVAL;
+		break;
+	case ESP_ERR_NOT_FOUND:
+		ret = -ENOENT;
+		break;
+	case ESP_ERR_NOT_SUPPORTED:
+		ret = -ENOTSUP;
+		break;
+	case ESP_ERR_TIMEOUT:
+		ret = -ETIMEDOUT;
+		break;
+	case ESP_ERR_INVALID_RESPONSE:
+		ret = -EBADMSG;
+		break;
+	case ESP_ERR_NOT_FINISHED:
+		ret = -EINPROGRESS;
+		break;
+	case ESP_ERR_NOT_ALLOWED:
+		ret = -EACCES;
+		break;
+	default:
+		/* Let's use EIO as a generic error */
+		ret = -EIO;
+		break;
+	}
+
+	return ret;
+}
+
+static bool _timer_cb(gptimer_handle_t timer,
+		      const gptimer_alarm_event_data_t *edata, void *user_ctx)
+{
+	BaseType_t higher_prio_task_woken = pdFALSE;
+
+	(void)gptimer_stop(timer);
+	xSemaphoreGiveFromISR(_symbol_sem, &higher_prio_task_woken);
+
+	/*
+	 * Return value: whether a high-priority task was awakened
+	 * to notify the scheduler to switch tasks
+	 */
+	return (higher_prio_task_woken == pdTRUE);
+}
+
+static int _timer_init(void)
+{
+	esp_err_t ret;
+
+	ret = gptimer_new_timer(&_timer_config, &_timer_handle);
+	if (ret != ESP_OK) {
+		return _esp_err_to_errno(ret);
+	}
+
+	gptimer_event_callbacks_t cb = {
+		.on_alarm = _timer_cb,
+	};
+
+	ret = gptimer_register_event_callbacks(_timer_handle, &cb, NULL);
+	if (ret != ESP_OK) {
+		(void)gptimer_del_timer(_timer_handle);
+		return _esp_err_to_errno(ret);
+	}
+
+	return 0;
+}
+
+static int _timer_start(uint32_t period_us)
+{
+	esp_err_t err;
+	gptimer_alarm_config_t alarm_config = {
+		.alarm_count = period_us,
+	};
+
+	err = gptimer_set_raw_count(_timer_handle, 0);
+	if (err != ESP_OK) {
+		return _esp_err_to_errno(err);
+	}
+
+	err = gptimer_set_alarm_action(_timer_handle, &alarm_config);
+	if (err != ESP_OK) {
+		return _esp_err_to_errno(err);
+	}
+	return _esp_err_to_errno(gptimer_start(_timer_handle));
+}
+
+static int _timer_enable(void)
+{
+	return _esp_err_to_errno(gptimer_enable(_timer_handle));
+}
+
+static int _timer_disable(void)
+{
+	(void)gptimer_stop(_timer_handle);
+	return _esp_err_to_errno(gptimer_disable(_timer_handle));
+}
+
+static int _radio_cw_start(uint16_t step, uint32_t delay, uint32_t duration_us)
+{
+	int ret;
+
+	/* Symbol on time */
+	phy_set_freq(HUBBLE_BASE_FREQUENCY, step);
+	phy_tx_tone(true, true, DEFAULT_TX_POWER_DBM);
+
+	ret = _timer_start(duration_us);
+	if (ret != 0) {
+		phy_tx_tone(false, true, DEFAULT_TX_POWER_DBM);
+		return ret;
+	}
+
+	xSemaphoreTake(_symbol_sem, portMAX_DELAY);
+
+	/* Symbol off time */
+	phy_tx_tone(false, true, DEFAULT_TX_POWER_DBM);
+
+	ret = _timer_start(delay);
+	if (ret != 0) {
+		return ret;
+	}
+
+	xSemaphoreTake(_symbol_sem, portMAX_DELAY);
+	return 0;
+}
+
+int hubble_sat_board_init(void)
+{
+	int ret;
+
+	ret = _timer_init();
+	if (ret != 0) {
+		return ret;
+	}
+
+	_symbol_sem = xSemaphoreCreateBinary();
+	if (_symbol_sem == NULL) {
+		(void)gptimer_del_timer(_timer_handle);
+		return -ENOMEM;
+	}
+
+	_transmit_sem = xSemaphoreCreateBinary();
+	if (_transmit_sem == NULL) {
+		(void)gptimer_del_timer(_timer_handle);
+		vSemaphoreDelete(_symbol_sem);
+		_symbol_sem = NULL;
+		return -ENOMEM;
+	}
+
+	/* Make count to 1 initially */
+	if (xSemaphoreGive(_transmit_sem) != pdTRUE) {
+		(void)gptimer_del_timer(_timer_handle);
+		vSemaphoreDelete(_transmit_sem);
+		vSemaphoreDelete(_symbol_sem);
+
+		_transmit_sem = NULL;
+		_symbol_sem = NULL;
+
+		return -EAGAIN;
+	}
+
+	esp_phy_rftest_init();
+	return 0;
+}
+
+int hubble_sat_board_enable(void)
+{
+	int ret = _timer_enable();
+	if (ret != 0) {
+		return ret;
+	}
+
+	esp_phy_rftest_config(1);
+	phy_set_step_01k(true);
+
+	return 0;
+}
+
+int hubble_sat_board_disable(void)
+{
+	esp_phy_rftest_config(0);
+	phy_set_step_01k(false);
+	return _timer_disable();
+}
+
+int hubble_sat_board_packet_send(const struct hubble_sat_packet_frames *packet)
+{
+	int ret = 0;
+	int8_t frame = -1;
+
+	xSemaphoreTake(_transmit_sem, portMAX_DELAY);
+	xSemaphoreTake(_symbol_sem, 0); /* Reset semaphore */
+
+	for (uint8_t i = 0; i < packet->total_number_of_symbols; i++) {
+		uint16_t step;
+		uint8_t data_pos = i % HUBBLE_PACKET_FRAME_PAYLOAD_MAX_SIZE;
+
+		if (data_pos == 0) {
+			frame++;
+		}
+
+		step = ESP_STEP_SCALE(
+			packet->frame[frame].data[data_pos] +
+			HUBBLE_CHANNEL_OFFSET(packet->frame[frame].channel));
+
+		/*
+		 * Because there's a certain delay for the radio to ramp up,
+		 * subtract the compensation to the off time delay
+		 */
+		ret = _radio_cw_start(
+			step, HUBBLE_WAIT_SYMBOL_OFF_US - ESP_RADIO_OFF_DELAY_US,
+			HUBBLE_WAIT_SYMBOL_US - ESP_RADIO_ON_DELAY_US);
+
+		if (ret != 0) {
+			break;
+		}
+	}
+
+	xSemaphoreGive(_transmit_sem);
+	return ret;
+}


### PR DESCRIPTION
Add Satellite support for ESP32C6 along with a quickstart on how to download Espressif PHY Lib early access blob.