### PR TITLE
docs: Group ephemeris APIs so they render in published docs

### DIFF
--- a/include/hubble/sat/ephemeris.h
+++ b/include/hubble/sat/ephemeris.h
@@ -21,6 +21,11 @@ extern "C" {
 #endif
 
 /**
+ * @addtogroup hubble_sat_api
+ * @{
+ */
+
+/**
  * @struct hubble_sat_orbital_params
  * @brief Represents the orbital parameters of a satellite.
  *
@@ -155,6 +160,9 @@ int hubble_next_pass_get(uint64_t t, const struct hubble_sat_device_pos *pos,
 int hubble_next_pass_region_get(uint64_t t,
 				const struct hubble_sat_device_region *region,
 				struct hubble_sat_pass_info *pass);
+
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Problem

The satellite ephemeris APIs (`hubble_sat_satellites_set`, `hubble_next_pass_get`, `hubble_next_pass_region_get`) and their structs are fully documented in `include/hubble/sat/ephemeris.h`, but they do **not** appear in the auto-generated GitHub Pages documentation.

## Root cause

The docs are built with Sphinx + Breathe. The satellite API page (`docs/satellite/api.rst`) pulls symbols in **only** via Breathe `.. doxygengroup::` directives, which render only symbols that belong to a named Doxygen group.

- `sat.h` → `@defgroup hubble_sat_api` ✅ rendered
- `packet.h` → `@defgroup hubble_sat_packet_api @ingroup hubble_sat_api` ✅ rendered
- `ephemeris.h` → every symbol had `@brief` but **none belonged to a group** ❌ → Doxygen scanned them, but Breathe had nothing to emit

## Fix

Wrap the ephemeris structs and functions in `@addtogroup hubble_sat_api { ... }`, adding them to the existing satellite API group already referenced by `api.rst`. No `.rst` change required.

## Verification

CI's `build-docs` workflow (or local `make doxygen && make html` in `docs/`) should now render the ephemeris structs and functions on the satellite API page.

## Note

`include/hubble/sat/dtm.h` has the same "no group" issue and is also absent from the docs. Left out of scope here — can be folded in if desired.