### PR TITLE
port: lock: Add a global lock used to protect shared data

### DIFF
--- a/include/hubble/port/sys.h
+++ b/include/hubble/port/sys.h
@@ -92,6 +92,39 @@ uint16_t hubble_sequence_counter_get(void);
 int hubble_log(enum hubble_log_level level, const char *format, ...);
 
 /**
+ * @brief Initialize the internal lock.
+ *
+ * Performs any one-time setup required to use @ref hubble_lock (for example,
+ * creating the underlying mutex on platforms that cannot statically initialize
+ * one). Called by hubble_init() before any locking takes place.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+int hubble_lock_init(void);
+
+/**
+ * @brief Acquire the internal lock.
+ *
+ * Provides mutual exclusion for the SDK's shared mutable state.
+ *
+ * The locked region includes the call to hubble_sequence_counter_get(), which
+ * may be application-provided and may block (for example, reading or persisting
+ * the counter from flash). The implementation must therefore be a
+ * blocking-capable mutex, NOT a non-blocking critical section such as scheduler
+ * suspension or an interrupt-disabling spinlock. Calls may be nested by the
+ * same execution context, so the mutex must be recursive. Initialized by
+ * @ref hubble_lock_init.
+ */
+void hubble_lock(void);
+
+/**
+ * @brief Release the internal lock.
+ *
+ * Releases a lock previously acquired with @ref hubble_lock.
+ */
+void hubble_unlock(void);
+
+/**
  * @brief Fill a buffer with random bytes.
  *
  * This function fills the provided buffer with random data using the

--- a/port/freertos/hubble_freertos.c
+++ b/port/freertos/hubble_freertos.c
@@ -6,12 +6,15 @@
 
 #ifdef CONFIG_ESP_IDF_BUILD
 #include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 #include <freertos/task.h>
 #else
 #include <FreeRTOS.h>
+#include <semphr.h>
 #include <task.h>
 #endif
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -33,6 +36,11 @@
 #elif defined(__GNUC__)
 #define HUBBLE_WEAK __attribute__((weak))
 #endif
+
+/*
+ * Recursive mutex, nested calls by the same task do not deadlock.
+ */
+static SemaphoreHandle_t _hubble_lock_sem;
 
 #ifndef CONFIG_HUBBLE_UPTIME_CUSTOM
 uint64_t hubble_uptime_get(void)
@@ -80,4 +88,26 @@ HUBBLE_WEAK int hubble_rand_get(uint8_t *buffer, size_t len)
 HUBBLE_WEAK int hubble_log(enum hubble_log_level level, const char *format, ...)
 {
 	return 0;
+}
+
+HUBBLE_WEAK int hubble_lock_init(void)
+{
+	if (_hubble_lock_sem == NULL) {
+		_hubble_lock_sem = xSemaphoreCreateRecursiveMutex();
+		if (_hubble_lock_sem == NULL) {
+			return -ENOMEM;
+		}
+	}
+
+	return 0;
+}
+
+HUBBLE_WEAK void hubble_lock(void)
+{
+	(void)xSemaphoreTakeRecursive(_hubble_lock_sem, portMAX_DELAY);
+}
+
+HUBBLE_WEAK void hubble_unlock(void)
+{
+	(void)xSemaphoreGiveRecursive(_hubble_lock_sem);
 }

--- a/port/zephyr/hubble_zephyr.c
+++ b/port/zephyr/hubble_zephyr.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log_output.h>
@@ -57,4 +58,22 @@ int hubble_rand_get(uint8_t *buffer, size_t len)
 	sys_rand_get(buffer, len);
 
 	return 0;
+}
+
+/* Recursive mutex: SMP-safe, blocking-capable, and statically initialized. */
+K_MUTEX_DEFINE(_hubble_lock);
+
+int hubble_lock_init(void)
+{
+	return 0;
+}
+
+void hubble_lock(void)
+{
+	(void)k_mutex_lock(&_hubble_lock, K_FOREVER);
+}
+
+void hubble_unlock(void)
+{
+	(void)k_mutex_unlock(&_hubble_lock);
 }

--- a/src/hubble.c
+++ b/src/hubble.c
@@ -53,8 +53,14 @@ uint64_t hubble_time_get(void)
 
 int hubble_init(uint64_t initial_time, const void *key)
 {
-	int ret = hubble_crypto_init();
+	int ret = hubble_lock_init();
 
+	if (ret != 0) {
+		HUBBLE_LOG_WARNING("Failed to initialize internal lock");
+		return ret;
+	}
+
+	ret = hubble_crypto_init();
 	if (ret != 0) {
 		HUBBLE_LOG_WARNING("Failed to initialize cryptography");
 		return ret;

--- a/src/hubble_ble.c
+++ b/src/hubble_ble.c
@@ -74,11 +74,10 @@ int hubble_ble_advertise_get(const uint8_t *input, size_t input_len,
 		return -EINVAL;
 	}
 
-	seq_no = hubble_sequence_counter_get();
-
-	if (!hubble_internal_nonce_values_check(time_counter, seq_no)) {
+	err = hubble_internal_sequence_acquire(time_counter, &seq_no);
+	if (err != 0) {
 		HUBBLE_LOG_WARNING("Re-using same nonce is insecure !");
-		return -EPERM;
+		return err;
 	}
 
 	// Set the constant data

--- a/src/hubble_crypto.c
+++ b/src/hubble_crypto.c
@@ -128,6 +128,26 @@ bool hubble_internal_nonce_values_check(uint32_t time_counter, uint16_t seq_no)
 	return true;
 }
 
+int hubble_internal_sequence_acquire(uint32_t time_counter, uint16_t *seq_no)
+{
+	int ret = 0;
+
+	/* Allocate the sequence number and validate the nonce as a single
+	 * critical section. Doing both under the lock prevents two concurrent
+	 * callers from being handed the same sequence number.
+	 */
+	hubble_lock();
+
+	*seq_no = hubble_sequence_counter_get();
+	if (!hubble_internal_nonce_values_check(time_counter, *seq_no)) {
+		ret = -EPERM;
+	}
+
+	hubble_unlock();
+
+	return ret;
+}
+
 static int _kbkdf_counter(const uint8_t *key, const char *label,
 			  size_t label_len, const uint8_t *context,
 			  size_t context_len, uint8_t *output, size_t olen)

--- a/src/hubble_priv.h
+++ b/src/hubble_priv.h
@@ -60,6 +60,22 @@ uint32_t hubble_internal_time_counter_get(void);
 bool hubble_internal_nonce_values_check(uint32_t time_counter, uint16_t seq_no);
 
 /**
+ * @brief Atomically allocate a sequence number and validate the nonce.
+ *
+ * Acquires the SDK lock and, as a single critical section, fetches the next
+ * sequence number via hubble_sequence_counter_get() and validates that the
+ * resulting (time_counter, seq_no) nonce has not been used. Doing these steps
+ * under the lock prevents concurrent callers from being handed the same
+ * sequence number, which would reuse the AES-CTR keystream.
+ *
+ * @param time_counter Current time-based counter value.
+ * @param seq_no       The allocated sequence number.
+ *
+ * @return 0 on success, -EPERM if using the nonce would result in reuse.
+ */
+int hubble_internal_sequence_acquire(uint32_t time_counter, uint16_t *seq_no);
+
+/**
  * @brief Get a derived device ID based on the time counter.
  *
  * This function generates a device identifier by deriving it from an

--- a/src/hubble_sat_packet.c
+++ b/src/hubble_sat_packet.c
@@ -252,7 +252,7 @@ int hubble_sat_packet_get(struct hubble_sat_packet *packet, const void *payload,
 	uint8_t ecc, payload_len;
 	uint8_t auth_tag[HUBBLE_AUTH_TAG_SIZE / HUBBLE_BITS_PER_BYTE];
 	uint8_t out[HUBBLE_PAYLOAD_MAX_SIZE] = {0};
-	uint16_t seq_no = hubble_sequence_counter_get();
+	uint16_t seq_no;
 	uint32_t time_counter = hubble_internal_time_counter_get();
 	uint32_t eid;
 
@@ -261,9 +261,10 @@ int hubble_sat_packet_get(struct hubble_sat_packet *packet, const void *payload,
 		return -EINVAL;
 	}
 
-	if (!hubble_internal_nonce_values_check(time_counter, seq_no)) {
+	ret = hubble_internal_sequence_acquire(time_counter, &seq_no);
+	if (ret != 0) {
 		HUBBLE_LOG_WARNING("Re-using same nonce is insecure !");
-		return -EPERM;
+		return ret;
 	}
 
 #define _CHECK_RET(_ret)                                                       \


### PR DESCRIPTION
The lock is need to guards sequence allocation for encryption operations to avoid possible nonce re-use. There is a possible race condition when two concurrent threads call `hubble_sequence_counter_get()` that may cause both threads to have the same sequence number assigned. The lock cannot be implemented only in the function returning the sequence number because the function that checks the nonce expect incremental sequence number and if that is not checked atomically with the sequence we may ending up rejecting valid sequence number.