### PR TITLE
sat: fix type warning when getting a packet for dtm mode

### DIFF
--- a/src/hubble_sat.c
+++ b/src/hubble_sat.c
@@ -180,7 +180,7 @@ int hubble_sat_dtm_packet_send(enum hubble_sat_dtm_packet_type type,
 		return -EINVAL;
 	}
 
-	hubble_rand_get(buffer, len);
+	hubble_rand_get((uint8_t *)buffer, len);
 
 	ret = hubble_sat_packet_get(&packet, buffer, len);
 	if (ret < 0) {


### PR DESCRIPTION
hubble_rand_get accepts a uint8_t pointer, but the buffer pass in is of type char pointer. Cast to the right type to make compiler happy.