### PR TITLE
sat: esp-idf: select PHY Lib automatically when enable sat network

### DIFF
--- a/docs/quickstart/esp-idf/index.rst
+++ b/docs/quickstart/esp-idf/index.rst
@@ -70,13 +70,6 @@ Adding Hubble Network to an ESP-IDF Project
       CONFIG_BT_BLE_50_FEATURES_SUPPORTED=n
       CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y
 
-   When enabling the Satellite Network module on ESP32-C6, you will also need to
-   include the PHY lib:
-
-   .. code-block:: kconfig
-
-      CONFIG_ESP_PHY_ENABLE_CERT_TEST=y
-
 
 Satellite Network on ESP32-C6: Required PHY Blob
 ************************************************

--- a/port/esp-idf/hubblenetwork-sdk/Kconfig
+++ b/port/esp-idf/hubblenetwork-sdk/Kconfig
@@ -28,6 +28,7 @@ endchoice
 
 menuconfig HUBBLE_SAT_NETWORK
 	   bool "Hubble Satellite Network Library [PRE-PRODUCTION]"
+	   select ESP_PHY_ENABLE_CERT_TEST
 	   help
 		Enable library for communication with Hubble network.
 		This feature is in pre-production and is not yet ready


### PR DESCRIPTION
Enable the module to select the PHY Lib automatically, which is needed for cw mode that is used in sat tx.