### PR TITLE
feat: Add ble-beacon-mfg-data sample

### DIFF
--- a/samples/zephyr/ble-beacon-mfg-data/CMakeLists.txt
+++ b/samples/zephyr/ble-beacon-mfg-data/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Hubble Network, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(app LANGUAGES C)
+
+# The Hubble master key is passed on the build command line as base64:
+#
+#   west build -b <board> . -- -DHUBBLE_KEY="<base64 key>"
+#
+# It is decoded into a C byte array here, at configure time, so no base64 code
+# ships in the firmware. Python3 is already a hard requirement of any Zephyr
+# build, so this adds no new dependency and runs automatically during the build.
+set(generated_key_c ${CMAKE_CURRENT_BINARY_DIR}/generated_master_key.c)
+
+if(NOT DEFINED HUBBLE_KEY OR "${HUBBLE_KEY}" STREQUAL "")
+  # No key passed (e.g. CI build-only). Emit an all-zero placeholder so the
+  # sample still compiles; it will not produce valid advertisements until a real
+  # key is supplied via -DHUBBLE_KEY.
+  message(WARNING
+    "HUBBLE_KEY not set; embedding an all-zero placeholder key. Pass your "
+    "base64 key with -DHUBBLE_KEY=\"<key>\" before flashing.")
+  # Match the format the decode branch emits (0x-prefixed, no trailing comma).
+  string(REPEAT "0x0," ${CONFIG_HUBBLE_KEY_SIZE} KEY_BYTES)
+  string(REGEX REPLACE ",$" "" KEY_BYTES "${KEY_BYTES}")
+else()
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} -c
+      "import base64,sys; print(','.join(hex(b) for b in base64.b64decode(sys.argv[1])))"
+      "${HUBBLE_KEY}"
+    OUTPUT_VARIABLE KEY_BYTES
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE decode_result)
+  if(NOT decode_result EQUAL 0)
+    message(FATAL_ERROR
+      "Failed to base64-decode HUBBLE_KEY; check that the key is valid base64.")
+  endif()
+endif()
+
+configure_file(src/master_key.c.in ${generated_key_c} @ONLY)
+
+target_sources(app PRIVATE src/main.c ${generated_key_c})

--- a/samples/zephyr/ble-beacon-mfg-data/Kconfig
+++ b/samples/zephyr/ble-beacon-mfg-data/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Hubble Network, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Application Kconfig entry point for the BLE beacon + manufacturer data sample.
+
+menu "Hubble Network Beacon + Manufacturer Data Sample options"
+
+config HUBBLE_MFG_DATA_SAMPLE_UPDATE_PERIOD
+    int "Period to refresh the advertisement and increment the counter"
+    default 300
+    help
+        Period (in seconds) at which a new Hubble advertisement is generated
+        and the manufacturer-data counter is incremented. Defaults to 5 minutes.
+
+endmenu
+
+source "Kconfig.zephyr"
+
+module = APP
+module-str = APP
+source "subsys/logging/Kconfig.template.log_config"

--- a/samples/zephyr/ble-beacon-mfg-data/README.md
+++ b/samples/zephyr/ble-beacon-mfg-data/README.md
@@ -1,0 +1,76 @@
+# Hubble Network BLE Beacon + Manufacturer Data Sample
+
+This sample demonstrates how to emit a **single** BLE advertisement that carries
+both the standard Hubble beacon payload **and** an application-owned
+*manufacturer specific data* field. The manufacturer field holds a 4-byte
+counter that is incremented every 5 minutes.
+
+Use this as a starting point when you need to attach your own data to a Hubble
+advertisement without sending it through the (encrypted) Hubble payload.
+
+The sample uses the **device uptime** counter source
+(`CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME`), so it does not need UTC time
+provisioned: the EID counter starts at 0 and advances with device uptime. Only
+the master key has to be embedded before building.
+
+## Advertisement layout
+
+The advertisement is built from three AD structures:
+
+| # | AD type | Contents |
+|---|---------|----------|
+| 1 | `BT_DATA_UUID16_ALL` | `0xFCA6` (the Hubble service UUID) |
+| 2 | `BT_DATA_SVC_DATA16` | Encrypted Hubble payload from `hubble_ble_advertise_get()` |
+| 3 | `BT_DATA_MANUFACTURER_DATA` | `0xFCA6` (2B, little-endian) + counter (4B, little-endian) |
+
+By BLE convention, manufacturer data begins with a 2-byte company identifier.
+This sample reuses Hubble's `0xFCA6` identifier as that prefix so scanners can
+recognize the field.
+
+> [!NOTE]
+> The counter is held in RAM and resets to 0 on reboot. Persisting it across
+> reboots is out of scope for this sample.
+
+## Size budget
+
+Legacy BLE advertising allows 31 payload bytes. This sample passes no Hubble
+user payload (`NULL, 0`), so the Hubble service data is 12 bytes and the whole
+advertisement is about 26 bytes. If you add Hubble user payload (up to 13
+bytes), it shares the same 31-byte budget with the manufacturer field, so you
+cannot max out both at once.
+
+## Requirements
+
+- A cryptographic key provided by Hubble Network.
+
+## Building and running
+
+Pass your base64 master key (the string Hubble gave you, already base64) on the
+build command line with `-DHUBBLE_KEY`. It is decoded into a byte array at build
+time, so no base64 code runs on the device and no pre-build script is needed.
+
+```sh
+west build -b nrf52840dk/nrf52840 . -- -DHUBBLE_KEY="<your base64 key>"
+west flash
+```
+
+After flashing, the device advertises as a Hubble beacon with the extra
+manufacturer-data counter, refreshing every 5 minutes.
+
+> [!NOTE]
+> The decoded key length must match `CONFIG_HUBBLE_KEY_SIZE` (32 bytes for a
+> 256-bit key, 16 for 128-bit). A wrong-size key fails the build with a clear
+> message; if `-DHUBBLE_KEY` is omitted the build uses an all-zero placeholder
+> (with a warning) so the sample still compiles in CI.
+
+> [!TIP]
+> `-DHUBBLE_KEY` is cached in the build directory, so subsequent incremental
+> `west build` runs reuse it without repeating the flag. Pass it again (or use
+> `-p always`) to change the key.
+
+## Configuration
+
+- `-DHUBBLE_KEY`: the base64-encoded Hubble master key, passed at build time and
+  decoded into the firmware (see above).
+- `CONFIG_HUBBLE_MFG_DATA_SAMPLE_UPDATE_PERIOD`: period in seconds at which the
+  advertisement is refreshed and the counter is incremented (default `300`).

--- a/samples/zephyr/ble-beacon-mfg-data/prj.conf
+++ b/samples/zephyr/ble-beacon-mfg-data/prj.conf
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Hubble Network, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Hubble Network
+CONFIG_HUBBLE_BLE_NETWORK=y
+
+# Use the device uptime counter source so the device does not need UTC time
+# provisioned. The EID counter starts from the value passed to hubble_init()
+# and advances with uptime.
+CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME=y
+
+# Bluetooth dependencies
+CONFIG_BT=y
+CONFIG_BT_PERIPHERAL=y
+
+CONFIG_MAIN_STACK_SIZE=2048

--- a/samples/zephyr/ble-beacon-mfg-data/sample.yaml
+++ b/samples/zephyr/ble-beacon-mfg-data/sample.yaml
@@ -1,0 +1,20 @@
+# This file is provided so that the application can be compiled using Twister,
+# the Zephyr testing tool.
+
+sample:
+  description: Hubble Network BLE Beacon + Manufacturer Data example
+  name: hubble-ble-beacon-mfg-data
+common:
+  build_only: true
+  depends_on:
+    - ble
+  integration_platforms:
+    - nrf52840dk/nrf52840
+tests:
+  app.beacon_mfg_data.default: {}
+  app.beacon_mfg_data.128key:
+    extra_configs:
+      - CONFIG_HUBBLE_NETWORK_KEY_128=y
+  app.beacon_mfg_data.mbedtls:
+    extra_configs:
+      - CONFIG_HUBBLE_NETWORK_CRYPTO_MBEDTLS=y

--- a/samples/zephyr/ble-beacon-mfg-data/src/main.c
+++ b/samples/zephyr/ble-beacon-mfg-data/src/main.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Hubble Network BLE Beacon + Manufacturer Data sample.
+ *
+ * This sample shows how to emit a SINGLE BLE advertisement that contains both
+ * the standard Hubble beacon payload AND an application-owned
+ * "manufacturer specific data" field. The manufacturer field carries a 4-byte
+ * counter that is incremented every time the advertisement is refreshed
+ * (every CONFIG_HUBBLE_MFG_DATA_SAMPLE_UPDATE_PERIOD seconds, 5 minutes by
+ * default).
+ *
+ * The advertisement is built from three AD (Advertising Data) structures:
+ *
+ *   [1] BT_DATA_UUID16_ALL      -> 0xFCA6, the Hubble service UUID. This is how
+ *                                  Hubble gateways recognize the beacon.
+ *   [2] BT_DATA_SVC_DATA16      -> the encrypted Hubble payload produced by
+ *                                  hubble_ble_advertise_get(). The buffer
+ *                                  already starts with the 0xFCA6 service UUID.
+ *   [3] BT_DATA_MANUFACTURER_DATA -> application data. By BLE convention this
+ *                                  field starts with a 2-byte company
+ *                                  identifier; here we reuse Hubble's 0xFCA6
+ *                                  identifier (little-endian) followed by a
+ *                                  4-byte little-endian counter.
+ *
+ * Advertisement size note: legacy BLE advertising allows 31 payload bytes.
+ * This sample passes no Hubble user payload (NULL, 0), so the Hubble service
+ * data is 12 bytes and the whole advertisement is ~26 bytes -- well under the
+ * limit. If you add Hubble user payload (up to 13 bytes) it shares the same
+ * 31-byte budget with the manufacturer field, so they cannot both be maxed.
+ *
+ * Key provisioning: the Hubble master key is passed on the build command line
+ * as base64 (west build ... -- -DHUBBLE_KEY="<key>") and decoded to a byte
+ * array at build time (see CMakeLists.txt), so no base64 code runs on the
+ * device. No pre-build script is required.
+ */
+
+#include <hubble/hubble.h>
+#include <hubble/ble.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/logging/log.h>
+
+#include <stdint.h>
+
+LOG_MODULE_REGISTER(main, CONFIG_APP_LOG_LEVEL);
+
+/*
+ * Master key, decoded from the -DHUBBLE_KEY base64 value at build time and
+ * defined in the generated source (see CMakeLists.txt). The SDK stores this
+ * pointer directly, so the array has static storage duration and outlives all
+ * SDK calls.
+ */
+extern const uint8_t master_key[];
+
+/*
+ * Buffer that receives the encrypted Hubble advertisement payload.
+ * 31 bytes is the maximum a legacy advertisement can hold.
+ */
+#define HUBBLE_USER_BUFFER_LEN 31
+static uint8_t hubble_buffer[HUBBLE_USER_BUFFER_LEN];
+
+/*
+ * Manufacturer-specific data: a 2-byte identifier prefix followed by a 4-byte
+ * counter. We reuse Hubble's 0xFCA6 identifier as the prefix. Both fields are
+ * little-endian, matching how BLE company identifiers are transmitted.
+ */
+#define MFG_DATA_COMPANY_ID HUBBLE_BLE_UUID /* 0xFCA6 */
+
+static struct {
+	uint16_t company_id;
+	uint32_t counter;
+} __packed mfg_data = {
+	.company_id = MFG_DATA_COMPANY_ID,
+	.counter = 0U,
+};
+
+/* The Hubble service UUID advertised in the UUID16 list. */
+static uint16_t adv_uuid = HUBBLE_BLE_UUID;
+
+/*
+ * The three AD structures that make up the advertisement. AD[1] (the Hubble
+ * service data) is filled in at runtime once we have generated the payload.
+ */
+static struct bt_data adv_data[] = {
+	BT_DATA(BT_DATA_UUID16_ALL, &adv_uuid, sizeof(adv_uuid)),
+	{0},
+	BT_DATA(BT_DATA_MANUFACTURER_DATA, &mfg_data, sizeof(mfg_data)),
+};
+
+/* Timer that wakes the main loop to refresh the advertisement. */
+K_SEM_DEFINE(timer_sem, 0, 1);
+
+static void timer_cb(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+	k_sem_give(&timer_sem);
+}
+
+K_TIMER_DEFINE(refresh_timer, timer_cb, NULL);
+
+int main(void)
+{
+	int err;
+	size_t out_len;
+
+	LOG_DBG("Hubble Network BLE Beacon + Manufacturer Data sample started");
+
+	/* Bring up the Bluetooth subsystem. */
+	err = bt_enable(NULL);
+	if (err != 0) {
+		LOG_ERR("Bluetooth init failed (err %d)", err);
+		return err;
+	}
+
+	/*
+	 * Initialize the Hubble SDK with the provisioned master key. This sample
+	 * uses the device uptime counter source
+	 * (CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME), so no UTC time is needed:
+	 * we pass 0 as the initial EID counter value and it advances with uptime.
+	 */
+	err = hubble_init(0, master_key);
+	if (err != 0) {
+		LOG_ERR("Failed to initialize Hubble BLE Network (err %d)", err);
+		goto end;
+	}
+
+	/* Refresh the advertisement on a fixed period (default 5 minutes). */
+	k_timer_start(&refresh_timer,
+		      K_SECONDS(CONFIG_HUBBLE_MFG_DATA_SAMPLE_UPDATE_PERIOD),
+		      K_SECONDS(CONFIG_HUBBLE_MFG_DATA_SAMPLE_UPDATE_PERIOD));
+
+	for (;;) {
+		/*
+		 * Generate the Hubble payload. We send no application payload
+		 * of our own through Hubble (NULL, 0); our custom data lives in
+		 * the manufacturer-data field instead.
+		 */
+		out_len = HUBBLE_USER_BUFFER_LEN;
+		err = hubble_ble_advertise_get(NULL, 0, hubble_buffer, &out_len);
+		if (err != 0) {
+			LOG_ERR("Failed to get advertisement data (err=%d)", err);
+			goto end;
+		}
+
+		/* Point AD[1] at the freshly generated Hubble service data. */
+		adv_data[1].type = BT_DATA_SVC_DATA16;
+		adv_data[1].data = hubble_buffer;
+		adv_data[1].data_len = out_len;
+
+		LOG_DBG("Hubble payload: %u bytes, counter: %u",
+			(unsigned int)out_len, mfg_data.counter);
+
+		/*
+		 * Start a non-connectable beacon using a Non-Resolvable Private
+		 * Address (NRPA); the actual address is derived by the Hubble
+		 * payload, so the advertised address rotates with the EID.
+		 */
+		err = bt_le_adv_start(
+			BT_LE_ADV_PARAM(BT_LE_ADV_OPT_USE_NRPA,
+					BT_GAP_ADV_FAST_INT_MIN_2,
+					BT_GAP_ADV_FAST_INT_MAX_2, NULL),
+			adv_data, ARRAY_SIZE(adv_data), NULL, 0);
+		if (err != 0) {
+			LOG_ERR("Advertisement start failed (err %d)", err);
+			goto end;
+		}
+
+		/* Wait until the timer fires. */
+		k_sem_take(&timer_sem, K_FOREVER);
+
+		err = bt_le_adv_stop();
+		if (err != 0) {
+			LOG_ERR("Advertisement stop failed (err %d)", err);
+			goto end;
+		}
+
+		/* Increment the counter for the next advertisement. */
+		mfg_data.counter++;
+	}
+
+end:
+	(void)bt_disable();
+	return err;
+}

--- a/samples/zephyr/ble-beacon-mfg-data/src/master_key.c.in
+++ b/samples/zephyr/ble-beacon-mfg-data/src/master_key.c.in
@@ -1,0 +1,18 @@
+/*
+ * Auto-generated from the -DHUBBLE_KEY base64 value at build time.
+ * Do not edit -- changes are overwritten on every build (see CMakeLists.txt).
+ */
+
+#include <stdint.h>
+#include <zephyr/sys/util.h>
+
+const uint8_t master_key[] = {@KEY_BYTES@};
+
+/*
+ * Catch a key whose decoded length does not match the configured key size
+ * (e.g. a 128-bit key with CONFIG_HUBBLE_NETWORK_KEY_256). Fails the build with
+ * a clear message instead of misbehaving at runtime.
+ */
+BUILD_ASSERT(sizeof(master_key) == CONFIG_HUBBLE_KEY_SIZE,
+	     "Decoded master key length does not match CONFIG_HUBBLE_KEY_SIZE; "
+	     "check -DHUBBLE_KEY and the configured key size.");

--- a/tools/ci/twister-quarantine.yaml
+++ b/tools/ci/twister-quarantine.yaml
@@ -1,6 +1,7 @@
 - scenarios:
     - app.beacon.mbedtls
     - app.beacon.mbedtls_128key
+    - app.beacon_mfg_data.mbedtls
     - app.ble_network.mbedtls
     - app.ble_network.mbedtls_128key
     - app.sat.continuous.mbedtls


### PR DESCRIPTION
Show SDK users how to attach their own data to a Hubble beacon without routing it through the encrypted Hubble payload. The sample emits a single advertisement carrying the Hubble service UUID, the Hubble service data, and a manufacturer-specific field (0xFCA6 prefix + a 4-byte counter incremented on each refresh) so the two coexist within the 31-byte legacy budget.

It uses the device uptime counter source so no UTC time has to be provisioned: hubble_init() takes 0 as the initial EID counter and it advances with uptime.

The master key is passed on the build command line as base64 (-DHUBBLE_KEY=...) and decoded to a byte array at build time (CMakeLists.txt invokes Python, already a Zephyr build requirement), so no base64 code ships on the device and there is no conf file or pre-build script to manage. A BUILD_ASSERT rejects a wrong-size key; omitting the key builds an all-zero placeholder for CI.

Kept deliberately bare-bones (no CTS sync, no NVS persistence) so it reads as reference material; the existing ble-beacon sample covers those.