### PR TITLE
samples: sat/esp-idf: add dual stack sample

### DIFF
--- a/samples/esp-idf/sat-dual-stack/CMakeLists.txt
+++ b/samples/esp-idf/sat-dual-stack/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Hubble Network, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+
+set(EXTRA_COMPONENT_DIRS ../../../port/esp-idf/)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# "Trim" the build. Include the minimal set of components, main, and anything it depends on.
+idf_build_set_property(MINIMAL_BUILD ON)
+
+project(sat-dual-stack LANGUAGES C)

--- a/samples/esp-idf/sat-dual-stack/README.md
+++ b/samples/esp-idf/sat-dual-stack/README.md
@@ -1,0 +1,162 @@
+# Hubble Satellite Dual-Stack on ESP-IDF
+
+This sample demonstrates how to run **BLE and the Hubble Satellite Network** on an ESP32-C6 using ESP-IDF.
+
+## Overview
+
+This project is designed to:
+
+- Demonstrate BLE and Hubble Satellite operation.
+- Provide a practical starting point for developers integrating Hubble Satellite Network alongside BLE on ESP32-C6 SoC.
+- Show how to use a BLE GATT service for runtime device provisioning (time and satellite ephemeris).
+
+## Features
+
+- Dual-stack application running Hubble Terrestrial (BLE) Network and the Hubble Satellite Network.
+- GATT provisioning service that provides time and satellite orbital parameters over BLE.
+
+## Requirements
+
+- Cryptographic key provided by Hubble Network
+- [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html)
+- ESP32-C6 hardware
+
+## Configuration
+
+The sample exposes the following options (via `idf.py menuconfig`, under
+"Sat Dual Stack Sample Configuration"):
+
+| Option                       | Default | Description                                                                          |
+| ---------------------------- | ------- | ------------------------------------------------------------------------------------ |
+| `CONFIG_HUBBLE_DEVICE_KEY`   | `""`    | Hubble device cryptographic key, base64-encoded.                                     |
+| `CONFIG_HUBBLE_SAMPLE_DEBUG` | `n`     | Enable debug mode, schedule sat tx in 2 minutes instead of waiting for the next pass |
+
+## Setup Instructions
+
+### 1. Install Dependencies
+
+First, set up the environment. This step assumes you've installed esp-idf
+to `~/esp/esp-idf`. If you haven't, follow the initial steps in the [Installation
+guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation) for your OS.
+
+```sh
+source ~/esp/esp-idf/export.sh
+```
+
+Install Python dependencies for the *dual-stack-companion.py* provisioning script:
+
+```bash
+pip install -r ../../../../tools/requirements-companion.txt
+```
+
+### 2. Build the Project
+
+Set the target chip to ESP32-C6:
+
+```sh
+idf.py set-target esp32c6
+```
+
+Configure the device key:
+
+```sh
+idf.py menuconfig
+```
+
+or add the config `CONFIG_HUBBLE_DEVICE_KEY="your_b64_key"` to
+`sdkconfig.defaults`.
+
+Next, `cd` to the sat-dual-stack example where you can build/flash/monitor:
+
+```sh
+idf.py build flash monitor
+```
+
+### 3. Provision the Device
+
+On first boot, the device starts a connectable BLE advertisement named **"Hubble-ESP"**
+and waits for provisioning data. Use *dual-stack-companion.py* to push the current Unix Epoch time,
+device location, and orbital parameters data for the target satellites:
+
+```bash
+export HUBBLE_API_TOKEN=<your-hubble-api-token>
+
+python ../../../../tools/dual-stack-companion.py
+```
+
+By default the device location is determined via IP geolocation. To provision an
+explicit location, pass the latitude and longitude (in degrees) with `--location`:
+
+```bash
+python ../../../../tools/dual-stack-companion.py --location <lat> <lon>
+```
+
+Once provisioning completes, the device automatically transitions into its
+satellite-pass scheduling loop and starts advertising the Hubble beacon.
+
+## Program Flow
+
+Once the firmware is flashed and the device has been provisioned:
+
+1. The device enters its main loop, alternating between BLE beacon
+   advertising and satellite transmission windows.
+2. At pass time, the device wakes from sleep and prepares to transmit.
+3. After the pass, the device returns to BLE beacon mode until the next pass.
+
+The beacon advertising payload refreshes periodically at 1 hour interval.
+
+The diagram below shows the full application life-cycle:
+
+```text
+                power on / reset
+                       |
+                       v
+       +-------------------------------+
+       |  Initialize stacks            |
+       |  (hubble_init + BLE)          |
+       +-------------------------------+
+                       |
+                       v
+       +------------------------------------+   no
+       |  Provisioned?                      |-----------+
+       |  (time, location, orbiral params)  |           |
+       +------------------------------------+           v
+                       |       +--------------------------------------+
+                       |       | Connectable advertising "Hubble-ESP" |
+                   yes |       |                                      |
+                       |       | dual-stack-companion.py writes time, |
+                       |       | location + orbital params over GATT  |
+                       |       +--------------------------------------+
+                       |                           |
+                       |<--------------------------+
+                       v
+      ==================  MAIN LOOP  ==================
+                       |
+                       v
+       +-------------------------------+
+       |  Compute next satellite pass  |<----------------+
+       |  (hubble_sat_next_pass_get)   |                 |
+       +-------------------------------+                 |
+                       |                                 |
+                       v                                 |
+       +-------------------------------+                 |
+       |  BLE beacon advertising       |                 |
+       |  (payload refreshes hourly)   |                 |
+       +-------------------------------+                 |
+                       |                                 |
+                       v                                 |
+       +-------------------------------+                 |
+       |  Sleep until pass time        |                 |
+       +-------------------------------+                 |
+                       |                                 |
+                       v                                 |
+       +-------------------------------+                 |
+       |  Stop BLE advertising         |                 |
+       +-------------------------------+                 |
+                       |                                 |
+                       v                                 |
+       +-------------------------------+   next pass     |
+       |  Satellite transmission       |-----------------+
+       |  (hubble_sat_packet_send)     |
+       +-------------------------------+
+```

--- a/samples/esp-idf/sat-dual-stack/main/CMakeLists.txt
+++ b/samples/esp-idf/sat-dual-stack/main/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Hubble Network, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set(SOURCES
+	"main.c"
+	"app_ble.c"
+)
+
+idf_component_register(SRCS ${SOURCES}
+		       PRIV_REQUIRES bt console nvs_flash esp_timer mbedtls hubblenetwork-sdk
+		       INCLUDE_DIRS ".")

--- a/samples/esp-idf/sat-dual-stack/main/Kconfig.projbuild
+++ b/samples/esp-idf/sat-dual-stack/main/Kconfig.projbuild
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Hubble Network, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Sat Dual Stack Sample Configuration"
+
+    orsource "$IDF_PATH/examples/common_components/env_caps/$IDF_TARGET/Kconfig.env_caps"
+
+    config HUBBLE_DEVICE_KEY
+    string "Cryptography key in base64"
+    default ""
+    help
+        Hubble device's cryptographic key
+
+    config HUBBLE_SAMPLE_DEBUG
+    bool "Enable debug mode"
+    default n
+    help
+        Enable debug mode for the Hubble sample application.
+        This will set the sat timer for 2 minutes instead
+        of until a satellite pass is overhead.
+
+endmenu

--- a/samples/esp-idf/sat-dual-stack/main/app_ble.c
+++ b/samples/esp-idf/sat-dual-stack/main/app_ble.c
@@ -1,0 +1,477 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+
+#include "esp_log.h"
+#include "esp_system.h"
+#include "esp_timer.h"
+
+/* ESP-IDF NimBLE includes */
+#include "nimble/nimble_port.h"
+#include "nimble/nimble_port_freertos.h"
+#include "host/ble_hs.h"
+#include "host/ble_gap.h"
+#include "host/ble_gatt.h"
+#include "host/util/util.h"
+#include "services/gap/ble_svc_gap.h"
+#include "services/gatt/ble_svc_gatt.h"
+
+#include <hubble/hubble.h>
+#include <hubble/ble.h>
+#include <hubble/sat/pass_prediction.h>
+
+#include "app_ble.h"
+
+static const char *BLE_TAG = "ble";
+
+#define CONFIG_BT_DEVICE_NAME          "Hubble-ESP"
+
+#define HUBBLE_BLE_UUID_CONNECTABLE    0xFCA7
+#define HUBBLE_BLE_BUFFER_LEN          31U
+
+#define ADV_INTERVAL_MIN_MS            1000
+#define ADV_INTERVAL_MAX_MS            1200
+
+/* Period to update adv packets in microseconds (1 hour) */
+#define HUBBLE_ADV_PACKET_PERIOD       3600000000UL
+
+/* TODO: replace this by actual command once finalized */
+#define HUBBLE_CMD                     0x01
+#define HUBBLE_CMD_UNIX_EPOCH          0x02
+#define HUBBLE_CMD_ORBITAL_PARAMS      0x03
+#define HUBBLE_CMD_DEVICE_LOCATION     0x04
+#define HUBBLE_ORBITAL_PARAMS_CMD_SIZE 76
+
+/*
+ * NOTE: If the caller is running in the same task as the NimBLE host, or if it
+ * is running in a higher priority task than that of the host, care must be
+ * taken when restarting advertising.  Under these conditions, the following is
+ * *not* a reliable method to restart advertising:
+ *     ble_gap_adv_stop()
+ *     ble_gap_adv_start()
+ *
+ * Since the refresh task will restart advertising, the caller runs on a lower
+ * priority than the NimBLE host.
+ */
+#define NIMBLE_HOST_TASK_STACK_SIZE    4096
+#define NIMBLE_HOST_TASK_PRIORITY      5
+#define ADV_REFRESH_TASK_STACK_SIZE    2048
+#define ADV_REFRESH_TASK_PRIORITY      4
+
+/*
+ * 128-bit UUIDs in little-endian byte order
+ * Service: 0000fca7-0000-1000-8000-00805f9b34fb
+ * Characteristic: 00000005-fca7-4000-8000-00805f9b34fb
+ */
+static const ble_uuid128_t _svc_uuid =
+	BLE_UUID128_INIT(0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80, 0x00,
+			 0x10, 0x00, 0x00, 0xa7, 0xfc, 0x00, 0x00);
+static const ble_uuid128_t _chr_uuid =
+	BLE_UUID128_INIT(0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80, 0x00,
+			 0x40, 0xa7, 0xfc, 0x05, 0x00, 0x00, 0x00);
+
+/* Extern variables */
+extern struct hubble_sat_device_pos device_pos;
+extern struct hubble_sat_orbital_params orb_params[];
+extern uint8_t orb_params_count;
+extern uint64_t unix_time_ms;
+
+/* Sem to sync time and orbital params */
+extern SemaphoreHandle_t sync_sem;
+
+/* Timers */
+static esp_timer_handle_t _ble_timer;
+
+/* Task notification for adv update */
+static TaskHandle_t _adv_refresh_task_handle;
+
+/* BLE adv specifics */
+static uint16_t _conn_adv_handle = BLE_HS_CONN_HANDLE_NONE;
+static uint8_t _beacon_adv_buffer[HUBBLE_BLE_BUFFER_LEN];
+
+/* Library function declarations */
+void ble_store_config_init(void);
+
+/* Forward declarations */
+static void _nimble_host_task(void *param);
+static void _start_connectable_adv(void);
+static int _chr_write_cb(uint16_t conn_handle, uint16_t attr_handle,
+			 struct ble_gatt_access_ctxt *ctxt, void *arg);
+
+/* GATT service (for conn adv) */
+static const struct ble_gatt_svc_def _gatt_svr_svcs[] = {
+	{
+		.type = BLE_GATT_SVC_TYPE_PRIMARY,
+		.uuid = &_svc_uuid.u,
+		.characteristics =
+			(struct ble_gatt_chr_def[]){
+				{
+					.uuid = &_chr_uuid.u,
+					.access_cb = _chr_write_cb,
+					.flags = BLE_GATT_CHR_F_WRITE |
+						 BLE_GATT_CHR_F_WRITE_NO_RSP,
+				},
+				{0}, /* No more characteristics */
+			},
+	},
+	/* No more services */
+	{0},
+};
+
+static void _ble_refresh_timer_cb(void *arg)
+{
+	xTaskNotifyGive(_adv_refresh_task_handle);
+}
+
+static void _adv_refresh_task(void *param)
+{
+	for (;;) {
+		ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+		if (!ble_gap_adv_active()) {
+			continue;
+		}
+
+		ble_adv_stop();
+		ble_adv_start();
+	}
+}
+
+/* BLE Beacon */
+int ble_adv_start(void)
+{
+	int rc;
+	esp_err_t ret;
+	size_t out_len = sizeof(_beacon_adv_buffer);
+
+	struct ble_hs_adv_fields adv_fields = {0};
+	struct ble_gap_adv_params adv_params = {
+		.conn_mode = BLE_GAP_CONN_MODE_NON,
+		.disc_mode = BLE_GAP_DISC_MODE_GEN,
+		.itvl_min = BLE_GAP_ADV_ITVL_MS(ADV_INTERVAL_MIN_MS),
+		.itvl_max = BLE_GAP_ADV_ITVL_MS(ADV_INTERVAL_MAX_MS),
+	};
+
+	/* Start BLE adv refresh timer */
+	ret = esp_timer_start_once(_ble_timer,
+				   (uint64_t)HUBBLE_ADV_PACKET_PERIOD);
+	if (ret != ESP_OK) {
+		ESP_LOGE(BLE_TAG,
+			 "Failed to start BLE adv refresh timer (ret=%d)", ret);
+		return -EINVAL;
+	}
+
+	/* Prepare the adv data */
+	memset(_beacon_adv_buffer, 0, sizeof(_beacon_adv_buffer));
+	rc = hubble_ble_advertise_get(NULL, 0, _beacon_adv_buffer, &out_len);
+	if (rc != 0) {
+		ESP_LOGE(BLE_TAG, "Failed to get Hubble adv data (rc=%d)", rc);
+		goto err_stop_timer;
+	}
+
+	adv_fields.uuids16 = (ble_uuid16_t[]){BLE_UUID16_INIT(HUBBLE_BLE_UUID)};
+	adv_fields.num_uuids16 = 1;
+	adv_fields.uuids16_is_complete = 1;
+
+	adv_fields.svc_data_uuid16 = _beacon_adv_buffer;
+	adv_fields.svc_data_uuid16_len = out_len;
+
+	adv_fields.name = (uint8_t *)CONFIG_BT_DEVICE_NAME;
+	adv_fields.name_len = strlen(CONFIG_BT_DEVICE_NAME);
+	adv_fields.name_is_complete = 1;
+
+	rc = ble_gap_adv_set_fields(&adv_fields);
+	if (rc != 0) {
+		ESP_LOGE(BLE_TAG, "Failed to set adv fields (rc=%d)", rc);
+		goto err_stop_timer;
+	}
+
+	rc = ble_gap_adv_start(BLE_OWN_ADDR_RANDOM, NULL, BLE_HS_FOREVER,
+			       &adv_params, NULL, NULL);
+	if (rc != 0 && rc != BLE_HS_EALREADY) {
+		ESP_LOGE(BLE_TAG, "Failed to start beacon adv (rc=%d)", rc);
+		goto err_stop_timer;
+	}
+
+	return 0;
+
+err_stop_timer:
+	(void)esp_timer_stop(_ble_timer);
+	return rc;
+}
+
+int ble_adv_stop(void)
+{
+	/* if already stop, do not call again */
+	if (!ble_gap_adv_active()) {
+		return 0;
+	}
+
+	(void)esp_timer_stop(_ble_timer);
+	return ble_gap_adv_stop();
+}
+
+/* Connectable Adv */
+static int _chr_write_cb(uint16_t conn_handle, uint16_t attr_handle,
+			 struct ble_gatt_access_ctxt *ctxt, void *arg)
+{
+	if (ctxt->op != BLE_GATT_ACCESS_OP_WRITE_CHR) {
+		return BLE_ATT_ERR_UNLIKELY;
+	}
+
+	struct os_mbuf *rx_mbuf = ctxt->om;
+	uint16_t len = OS_MBUF_PKTLEN(rx_mbuf);
+
+	uint8_t header[2];
+	if (len < 2 || os_mbuf_copydata(rx_mbuf, 0, 2, header) != 0) {
+		return BLE_ATT_ERR_REQ_NOT_SUPPORTED;
+	}
+
+	if (header[0] != HUBBLE_CMD) {
+		return BLE_ATT_ERR_REQ_NOT_SUPPORTED;
+	}
+
+	switch (header[1]) {
+	case HUBBLE_CMD_UNIX_EPOCH:
+		if (len != (2 + sizeof(uint64_t))) {
+			return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+		}
+
+		os_mbuf_copydata(rx_mbuf, 2, sizeof(unix_time_ms), &unix_time_ms);
+
+		ESP_LOGI(BLE_TAG, "Received unix time: %llu", unix_time_ms);
+		break;
+
+	case HUBBLE_CMD_ORBITAL_PARAMS: {
+		if (len != (2 + HUBBLE_ORBITAL_PARAMS_CMD_SIZE)) {
+			return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+		}
+
+		if (orb_params_count >= HUBBLE_MAX_SAT) {
+			ESP_LOGW(BLE_TAG, "Max satellite count reached, cannot "
+					  "add more orbital params");
+			break;
+		}
+
+		struct hubble_sat_orbital_params *dst =
+			&orb_params[orb_params_count];
+		uint8_t orb_params_data[HUBBLE_ORBITAL_PARAMS_CMD_SIZE];
+		os_mbuf_copydata(rx_mbuf, 2, HUBBLE_ORBITAL_PARAMS_CMD_SIZE,
+				 orb_params_data);
+
+		/* Let's copy field by field to avoid alignment issues */
+		memcpy(&dst->t0, orb_params_data, sizeof(uint64_t));
+		memcpy(&dst->n0, orb_params_data + 8, sizeof(double));
+		memcpy(&dst->ndot, orb_params_data + 16, sizeof(double));
+		memcpy(&dst->raan0, orb_params_data + 24, sizeof(double));
+		memcpy(&dst->raandot, orb_params_data + 32, sizeof(double));
+		memcpy(&dst->aop0, orb_params_data + 40, sizeof(double));
+		memcpy(&dst->aopdot, orb_params_data + 48, sizeof(double));
+		memcpy(&dst->inclination, orb_params_data + 56, sizeof(double));
+		memcpy(&dst->eccentricity, orb_params_data + 64, sizeof(double));
+		memcpy(&dst->satellite_id, orb_params_data + 72,
+		       sizeof(uint32_t));
+
+		++orb_params_count;
+
+		ESP_LOGI(BLE_TAG, "Received orbital params for satellite ID %u",
+			 dst->satellite_id);
+		break;
+	}
+
+	case HUBBLE_CMD_DEVICE_LOCATION:
+		if (len != (2 + 2 * sizeof(double))) {
+			return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+		}
+
+		os_mbuf_copydata(rx_mbuf, 2, sizeof(double), &device_pos.lat);
+		os_mbuf_copydata(rx_mbuf, 2 + sizeof(double), sizeof(double),
+				 &device_pos.lon);
+
+		ESP_LOGI(BLE_TAG, "Received device location: lat=%f, lon=%f",
+			 device_pos.lat, device_pos.lon);
+		break;
+
+	default:
+		return BLE_ATT_ERR_REQ_NOT_SUPPORTED;
+	}
+
+	return 0;
+}
+
+static int _gap_event_handler(struct ble_gap_event *event, void *arg)
+{
+	switch (event->type) {
+	case BLE_GAP_EVENT_CONNECT:
+		if (event->connect.status == 0) {
+			_conn_adv_handle = event->connect.conn_handle;
+			ESP_LOGD(BLE_TAG, "Connected (handle=%d)",
+				 _conn_adv_handle);
+
+		} else {
+			ESP_LOGW(BLE_TAG, "Connection failed, restarting adv");
+			_start_connectable_adv();
+		}
+		break;
+
+	case BLE_GAP_EVENT_DISCONNECT:
+		ESP_LOGD(BLE_TAG, "Disconnected (reason=0x%02x)",
+			 event->disconnect.reason);
+		_conn_adv_handle = BLE_HS_CONN_HANDLE_NONE;
+
+		if (unix_time_ms != 0) {
+			xSemaphoreGive(sync_sem);
+		} else {
+			_start_connectable_adv();
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static void _start_connectable_adv(void)
+{
+	int rc;
+	struct ble_hs_adv_fields adv_fields = {0};
+	struct ble_gap_adv_params adv_params = {
+		.conn_mode = BLE_GAP_CONN_MODE_UND,
+		.disc_mode = BLE_GAP_DISC_MODE_GEN,
+		.itvl_min = BLE_GAP_ADV_FAST_INTERVAL2_MIN,
+		.itvl_max = BLE_GAP_ADV_FAST_INTERVAL2_MAX,
+	};
+
+	static uint8_t svc_data[] = {
+		HUBBLE_BLE_UUID_CONNECTABLE & 0xFF,
+		HUBBLE_BLE_UUID_CONNECTABLE >> 8,
+	};
+
+	adv_fields.uuids16 =
+		(ble_uuid16_t[]){BLE_UUID16_INIT(HUBBLE_BLE_UUID_CONNECTABLE)};
+	adv_fields.num_uuids16 = 1;
+	adv_fields.uuids16_is_complete = 1;
+
+	adv_fields.svc_data_uuid16 = svc_data;
+	adv_fields.svc_data_uuid16_len = sizeof(svc_data);
+
+	adv_fields.name = (uint8_t *)CONFIG_BT_DEVICE_NAME;
+	adv_fields.name_len = strlen(CONFIG_BT_DEVICE_NAME);
+	adv_fields.name_is_complete = 1;
+
+	rc = ble_gap_adv_set_fields(&adv_fields);
+	if (rc != 0) {
+		ESP_LOGE(BLE_TAG,
+			 "Failed to set connectable adv fields (rc=%d)", rc);
+		return;
+	}
+
+	rc = ble_gap_adv_start(BLE_OWN_ADDR_RANDOM, NULL, BLE_HS_FOREVER,
+			       &adv_params, _gap_event_handler, NULL);
+	if (rc != 0) {
+		ESP_LOGE(BLE_TAG, "Failed to start connectable adv (rc=%d)", rc);
+	}
+}
+
+/* NimBLE host stack */
+static void _nimble_host_task(void *param)
+{
+	/* This function won't return until nimble_port_stop() is executed */
+	nimble_port_run();
+
+	/* Clean up at exit */
+	vTaskDelete(NULL);
+}
+
+static void _on_nimble_stack_reset(int reason)
+{
+	ESP_LOGW(BLE_TAG, "NimBLE stack reset (reason=%d)", reason);
+}
+
+static void _on_nimble_stack_sync(void)
+{
+	/* 1 = random address */
+	int rc = ble_hs_util_ensure_addr(1);
+	if (rc != 0) {
+		ESP_LOGE(BLE_TAG, "Failed to ensure address (rc=%d)", rc);
+		return;
+	}
+
+	_start_connectable_adv();
+}
+
+int ble_init(void)
+{
+	int rc;
+	esp_err_t ret;
+
+	/* Create / Init timers and sems */
+	esp_timer_create_args_t ble_timer_args = {
+		.callback = _ble_refresh_timer_cb,
+		.name = "ble_adv_refresh",
+	};
+
+	ret = esp_timer_create(&ble_timer_args, &_ble_timer);
+	if (ret != ESP_OK) {
+		ESP_LOGE(BLE_TAG, "Failed to create BLE timer (rc=%d)", ret);
+		return -EINVAL;
+	}
+
+	ret = nimble_port_init();
+	if (ret != ESP_OK) {
+		ESP_LOGE(BLE_TAG, "Failed to init NimBLE (rc=%d)", ret);
+		return -EAGAIN;
+	}
+
+	/* Register GATT services */
+	ble_svc_gap_init();
+	ble_svc_gatt_init();
+
+	/* Update GATT service couner and add the service */
+	rc = ble_gatts_count_cfg(_gatt_svr_svcs);
+	if (rc != 0) {
+		ESP_LOGE(BLE_TAG, "Failed to count GATT services (rc=%d)", rc);
+		goto exit;
+	}
+
+	rc = ble_gatts_add_svcs(_gatt_svr_svcs);
+	if (rc != 0) {
+		ESP_LOGE(BLE_TAG, "Failed to add GATT services (rc=%d)", rc);
+		goto exit;
+	}
+
+	/* Host callbacks */
+	ble_hs_cfg.reset_cb = _on_nimble_stack_reset;
+	ble_hs_cfg.sync_cb = _on_nimble_stack_sync;
+	ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
+
+	ble_store_config_init();
+	xTaskCreate(_nimble_host_task, "NimBLE_Host", NIMBLE_HOST_TASK_STACK_SIZE,
+		    NULL, NIMBLE_HOST_TASK_PRIORITY, NULL);
+
+	/* adv refresh task */
+	xTaskCreate(_adv_refresh_task, "adv_refresh", ADV_REFRESH_TASK_STACK_SIZE,
+		    NULL, ADV_REFRESH_TASK_PRIORITY, &_adv_refresh_task_handle);
+
+	return 0;
+
+exit:
+	/* Clean up resources */
+	ble_svc_gap_deinit();
+	ble_svc_gatt_deinit();
+	(void)esp_timer_delete(_ble_timer);
+	(void)nimble_port_deinit();
+
+	return rc;
+}

--- a/samples/esp-idf/sat-dual-stack/main/app_ble.h
+++ b/samples/esp-idf/sat-dual-stack/main/app_ble.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 HubbleNetwork
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file app_ble.h
+ * @brief Bluetooth LE advertising interface.
+ *
+ * Provides functions to initialize the BLE stack and control advertising.
+ */
+
+#ifndef APP_BLE_H
+#define APP_BLE_H
+
+#include "esp_err.h"
+
+/**
+ * @brief Maximum number of satellites provisioned over GATT.
+ */
+#define HUBBLE_MAX_SAT 6
+
+/**
+ * @brief Initialize the Bluetooth LE subsystem.
+ *
+ * Registers GATT services, sets up the advertising data, prepares the
+ * controller for use, and starts the time / orbital parameters sync over BLE.
+ * Must be called once before any other BLE function.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int ble_init(void);
+
+/**
+ * @brief Start Bluetooth LE advertising.
+ *
+ * Begins broadcasting advertisement packets. @ref ble_init must have been
+ * called successfully before invoking this function.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int ble_adv_start(void);
+
+/**
+ * @brief Stop Bluetooth LE advertising.
+ *
+ * Halts advertisement broadcasting. Safe to call even if advertising is
+ * already stopped.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int ble_adv_stop(void);
+
+#endif /* APP_BLE_H */

--- a/samples/esp-idf/sat-dual-stack/main/main.c
+++ b/samples/esp-idf/sat-dual-stack/main/main.c
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+/* FreeRTOS */
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+
+/* ESP-IDF components */
+#include "esp_log.h"
+#include "esp_system.h"
+#include "esp_timer.h"
+#include "nvs_flash.h"
+#include "mbedtls/base64.h"
+
+#include <hubble/hubble.h>
+#include <hubble/sat/packet.h>
+#include <hubble/sat/pass_prediction.h>
+
+#include "app_ble.h"
+
+static const char *APP_TAG = "main";
+
+#define MS_PER_SEC 1000U
+#define US_PER_MS  1000U
+#define US_PER_SEC 1000000ULL
+
+/* Device location and sat orbital parameters */
+struct hubble_sat_device_pos device_pos;
+struct hubble_sat_orbital_params orb_params[HUBBLE_MAX_SAT];
+uint8_t orb_params_count;
+
+/* Hubble device key and time */
+static uint8_t _hubble_key[CONFIG_HUBBLE_KEY_SIZE];
+uint64_t unix_time_ms;
+
+/* Sem for sync time / orb params and wait for sat tx */
+SemaphoreHandle_t sync_sem;
+static SemaphoreHandle_t _sat_tx_sem;
+
+static esp_timer_handle_t _sat_timer;
+
+static void _sat_timer_cb(void *arg)
+{
+	xSemaphoreGive(_sat_tx_sem);
+}
+
+/*
+ * NOTE: this function has many early returns.
+ * For production code, we should clean up resources (sem, timers, deinit stack, etc.)
+ * on each failure case.
+ * For simplicity of the sample, we just exit on failure.
+ */
+void app_main(void)
+{
+	struct hubble_sat_pass_info pass_info = {0};
+	struct hubble_sat_packet packet = {0};
+	esp_timer_create_args_t sat_timer_args = {0};
+	uint64_t now_ms;
+	uint64_t sat_wait_us;
+	esp_err_t err;
+	int ret;
+
+	/* NVS flash init – dependency of NimBLE stack */
+	err = nvs_flash_init();
+	if (err == ESP_ERR_NVS_NO_FREE_PAGES ||
+	    err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+		ESP_ERROR_CHECK(nvs_flash_erase());
+		err = nvs_flash_init();
+	}
+	ESP_ERROR_CHECK(err);
+
+	/* Decode device key */
+	if (strlen(CONFIG_HUBBLE_DEVICE_KEY) != 0) {
+		size_t outlen = 0;
+
+		ret = mbedtls_base64_decode(
+			_hubble_key, sizeof(_hubble_key), &outlen,
+			(const unsigned char *)CONFIG_HUBBLE_DEVICE_KEY,
+			strlen(CONFIG_HUBBLE_DEVICE_KEY));
+
+		if (ret != 0) {
+			ESP_LOGE(APP_TAG, "Invalid key provided!");
+			return;
+		}
+
+		if (outlen != sizeof(_hubble_key)) {
+			ESP_LOGE(APP_TAG, "Invalid key length provided!");
+			return;
+		}
+	}
+
+	/* Create the sat timer */
+	sat_timer_args.callback = _sat_timer_cb;
+	sat_timer_args.name = "sat_timer";
+
+	err = esp_timer_create(&sat_timer_args, &_sat_timer);
+	if (err != ESP_OK) {
+		ESP_LOGE(APP_TAG, "Failed to create sat timer (rc=%d)", err);
+		return;
+	}
+
+	/* Init the sem */
+	_sat_tx_sem = xSemaphoreCreateBinary();
+	sync_sem = xSemaphoreCreateBinary();
+
+	if (_sat_tx_sem == NULL || sync_sem == NULL) {
+		ESP_LOGE(APP_TAG, "Failed to create semaphores");
+		return;
+	}
+
+	/* Init and enable BLE */
+	ret = ble_init();
+	if (ret != 0) {
+		ESP_LOGE(APP_TAG, "Failed to init BLE, ret: %d", ret);
+		return;
+	}
+
+	/* We sit here waiting to have time */
+	xSemaphoreTake(sync_sem, portMAX_DELAY);
+
+	/* Init Hubble */
+	ret = hubble_init(unix_time_ms, _hubble_key);
+	if (ret != 0) {
+		ESP_LOGE(APP_TAG,
+			 "Failed to initialize Hubble Network, ret: %d", ret);
+		return;
+	}
+
+	/* Set sats params */
+	ret = hubble_sat_satellites_set(orb_params, orb_params_count);
+	if (ret != 0) {
+		ESP_LOGE(APP_TAG,
+			 "Failed to set satellite orbital params data, ret: %d",
+			 ret);
+		return;
+	}
+
+	ESP_LOGI(APP_TAG, "Hubble Network initialized");
+
+	for (;;) {
+		/* Calculate the next pass time */
+		now_ms = hubble_time_get();
+		ret = hubble_sat_next_pass_get(now_ms, &device_pos, &pass_info);
+		if (ret != 0) {
+			ESP_LOGE(APP_TAG,
+				 "Failed to get next pass info, err: %d", ret);
+			return;
+		}
+
+		/*
+		 * If the pass start <= current time, this means we're in the
+		 * middle of a pass. We can compute the next one
+		 */
+		if (pass_info.start <= now_ms) {
+			ESP_LOGI(APP_TAG, "Current pass is ongoing or in the "
+					  "past, search for next pass...");
+
+			ret = hubble_sat_next_pass_get(
+				pass_info.start + pass_info.duration,
+				&device_pos, &pass_info);
+			if (ret != 0) {
+				ESP_LOGE(APP_TAG,
+					 "Failed to get next pass info: %d", ret);
+				return;
+			}
+		}
+
+#ifdef CONFIG_HUBBLE_SAMPLE_DEBUG
+		sat_wait_us = 120 * US_PER_SEC;
+		ESP_LOGI(APP_TAG, "Next pass in 120 seconds");
+#else
+		ESP_LOGI(APP_TAG, "Next pass at: %llu (unix epoch seconds)",
+			 pass_info.start / MS_PER_SEC);
+
+		/* Schedule the pass */
+		sat_wait_us = (pass_info.start - now_ms) * US_PER_MS;
+#endif
+		err = esp_timer_start_once(_sat_timer, sat_wait_us);
+		if (err != ESP_OK) {
+			ESP_LOGE(APP_TAG, "Failed to start sat timer, ret: %d",
+				 err);
+			return;
+		}
+
+		/* Start BLE advertising */
+		ret = ble_adv_start();
+		if (ret != 0) {
+			ESP_LOGE(APP_TAG,
+				 "Failed to start advertising, ret: %d", ret);
+			return;
+		}
+		ESP_LOGI(APP_TAG, "Starting BLE advertising...");
+
+		/* Wait for sat pass */
+		xSemaphoreTake(_sat_tx_sem, portMAX_DELAY);
+
+		/* Stop BLE and start sat tx */
+		ret = ble_adv_stop();
+		if (ret != 0) {
+			ESP_LOGE(APP_TAG, "Failed to stop advertising, ret: %d",
+				 ret);
+			return;
+		}
+
+		ret = hubble_sat_packet_get(&packet, NULL, 0);
+		if (ret != 0) {
+			ESP_LOGE(APP_TAG, "Failed to get sat packet, ret: %d",
+				 ret);
+			return;
+		}
+
+		ESP_LOGI(APP_TAG, "Starting satellite transmission...");
+		ret = hubble_sat_packet_send(&packet,
+					     HUBBLE_SAT_RELIABILITY_NORMAL);
+		if (ret != 0) {
+			ESP_LOGE(APP_TAG, "Failed to send sat packet, ret: %d",
+				 ret);
+			return;
+		}
+	}
+}

--- a/samples/esp-idf/sat-dual-stack/sdkconfig.defaults
+++ b/samples/esp-idf/sat-dual-stack/sdkconfig.defaults
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Hubble Network, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Bluetooth
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+CONFIG_BT_NIMBLE_50_FEATURE_SUPPORT=n
+
+# Hubble Network
+CONFIG_HUBBLE_BLE_NETWORK=y
+CONFIG_HUBBLE_SAT_NETWORK=y

--- a/tools/ci/esp-idf-build-manifest.yaml
+++ b/tools/ci/esp-idf-build-manifest.yaml
@@ -8,6 +8,11 @@ samples/esp-idf/sat-continuous:
     - if: IDF_TARGET == "esp32c6"
       reason: sat functionality only supported on esp32c6
 
+samples/esp-idf/sat-dual-stack:
+  enable:
+    - if: IDF_TARGET == "esp32c6"
+      reason: sat functionality only supported on esp32c6
+
 samples/esp-idf/sat-dtm:
   enable:
     - if: IDF_TARGET == "esp32c6"


### PR DESCRIPTION
Add dual stack sample application for ESP-IDF:

- Sync time and orbital params.
- Periodic Hubble Terrestrial (BLE) beacon.
- Wake up and transmit to satellite.