### PR TITLE
fixes: Random fixes / improvements

### DIFF
--- a/port/freertos/hubble_freertos.c
+++ b/port/freertos/hubble_freertos.c
@@ -15,6 +15,8 @@
 #endif
 
 #include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -72,8 +74,18 @@ uint64_t hubble_uptime_get(void)
 
 HUBBLE_WEAK int hubble_rand_get(uint8_t *buffer, size_t len)
 {
+	static bool seeded;
 	int random;
 	size_t to_copy;
+
+	/**
+	 * Best-effort one-time seed so the sequence is not identical across
+	 * boots.
+	 **/
+	if (!seeded) {
+		srand((unsigned int)(xTaskGetTickCount() ^ (uintptr_t)&buffer));
+		seeded = true;
+	}
 
 	while (len > 0) {
 		random = rand();

--- a/src/hubble_sat_packet.c
+++ b/src/hubble_sat_packet.c
@@ -106,7 +106,12 @@ static int _encode(const struct hubble_bitarray *bit_array, int *symbols,
 	int symbol_bit_index = 0;
 	int index = 0;
 
-	if ((bit_array->index / HUBBLE_SYMBOL_SIZE) > symbols_size) {
+	/**
+	 * Account for the trailing padding symbol written when the bit count is
+	 * not a multiple of HUBBLE_SYMBOL_SIZE.
+	 */
+	if (((bit_array->index + HUBBLE_SYMBOL_SIZE - 1) / HUBBLE_SYMBOL_SIZE) >
+	    symbols_size) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
- Fix possible off by one issue in `_encode`. Although it is not a problem right now because of the size of buffers we use, the algorithm itself has an issue and may cause a problem in future.
- Seed PRNG in FreeRTOS to avoid possible same random values across boots