### PR TITLE
sat: pass-prediction: add  minimum elevation angle setter

### DIFF
--- a/include/hubble/sat/pass_prediction.h
+++ b/include/hubble/sat/pass_prediction.h
@@ -161,6 +161,24 @@ int hubble_sat_next_pass_region_get(
 	uint64_t t, const struct hubble_sat_device_region *region,
 	struct hubble_sat_pass_info *pass);
 
+/**
+ * @brief Set the minimum elevation angle for a satellite pass.
+ *
+ * This function configures the minimum elevation angle above the horizon that a
+ * satellite must reach at culmination for a pass to be reported by
+ * hubble_sat_next_pass_get() and hubble_sat_next_pass_region_get(). Passes whose
+ * maximum elevation angle is below this threshold are ignored.
+ *
+ * Raising the angle restricts results to higher, closer passes (typically better
+ * link quality) at the cost of fewer reported passes. The default minimum
+ * elevation angle is 45 degrees.
+ *
+ * @param angle Minimum elevation angle in degrees. Must be in the range [30, 90].
+ * @return 0 on success.
+ * @retval -EINVAL if @p angle is outside the range [30, 90].
+ */
+int hubble_sat_min_elevation_angle_set(uint8_t angle);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/src/hubble_sat_pass_prediction.c
+++ b/src/hubble_sat_pass_prediction.c
@@ -21,7 +21,6 @@
 #define HUBBLE_TWO_PI_DEGREES            360
 #define HUBBLE_TWO_PI                    (2.0 * M_PI)
 #define HUBBLE_PI_DEGREES                180
-#define HUBBLE_ELEVATION_ANGLE_TOLERANCE 30
 
 #define HUBBLE_PI_2                      1.57079632679489661923  /* PI / 2 */
 #define HUBBLE_PI_4                      0.785398163397448309616 /* PI / 4 */
@@ -58,6 +57,7 @@ static const struct {
 
 static const struct hubble_sat_orbital_params *_satellites;
 static size_t _satellites_count;
+static uint8_t _elevation_angle_tolerance = 45;
 
 #ifdef CONFIG_HUBBLE_SAT_NETWORK_SMALL
 
@@ -546,7 +546,7 @@ static double _lon_tolerance_get(double lat, double sat_altitude)
 {
 	double A, C, b, B;
 
-	A = _DEG2RAD(HUBBLE_ELEVATION_ANGLE_TOLERANCE + 90);
+	A = _DEG2RAD(_elevation_angle_tolerance + 90.0);
 
 	C = _asin(earth.radius * _sin(A) / (earth.radius + sat_altitude));
 	b = earth.radius * _cos(M_PI - _asin((earth.radius + sat_altitude) *
@@ -1040,6 +1040,17 @@ int hubble_sat_next_pass_region_get(
 			 (unsigned long long)pass->culmination, pass->lon,
 			 (unsigned long long)pass->duration, (int)ascending,
 			 pass->max_elevation_angle);
+
+	return 0;
+}
+
+int hubble_sat_min_elevation_angle_set(uint8_t angle)
+{
+	if ((angle < 30U) || (angle > 90U)) {
+		return -EINVAL;
+	}
+
+	_elevation_angle_tolerance = angle;
 
 	return 0;
 }

--- a/tests/zephyr/pass-prediction/src/main.c
+++ b/tests/zephyr/pass-prediction/src/main.c
@@ -216,4 +216,12 @@ ZTEST(satellite_pass_prediction_test,
 	}
 }
 
-ZTEST_SUITE(satellite_pass_prediction_test, NULL, NULL, NULL, NULL, NULL);
+static void *pass_prediction_init(void)
+{
+	(void)hubble_sat_min_elevation_angle_set(30);
+
+	return NULL;
+}
+
+ZTEST_SUITE(satellite_pass_prediction_test, NULL, pass_prediction_init, NULL,
+	    NULL, NULL);


### PR DESCRIPTION
Replace the compile-time HUBBLE_ELEVATION_ANGLE_TOLERANCE macro with a runtime setter, hubble_sat_min_elevation_angle_set(), so applications can tune the minimum elevation that a pass must reach to be valid.