### PR TITLE
samples: zephyr: sat-continuous: provision key at build time

### DIFF
--- a/samples/zephyr/sat-continuous/CMakeLists.txt
+++ b/samples/zephyr/sat-continuous/CMakeLists.txt
@@ -6,4 +6,13 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(app LANGUAGES C)
 
+# The Hubble master key is provisioned at build time via the
+# CONFIG_SAMPLE_HUBBLE_KEY Kconfig option (a base64 string), e.g.
+#
+#   west build -b <board> . -- -DCONFIG_SAMPLE_HUBBLE_KEY="<base64 key>"
+#
+# It is decoded into bytes at runtime (Zephyr provides base64_decode). If it is
+# omitted (e.g. a CI build-only run) the firmware falls back to an all-zero
+# placeholder. See src/main.c and Kconfig.
+
 target_sources(app PRIVATE src/main.c)

--- a/samples/zephyr/sat-continuous/Kconfig
+++ b/samples/zephyr/sat-continuous/Kconfig
@@ -10,6 +10,23 @@ config SAMPLE_PROVIDE_SAT_BOARD_SUPPORT
 	Targets that support satellite must select it, otherwise
 	board APIs will be mocked in the sample.
 
+config SAMPLE_SAT_TX_INTERVAL_SECONDS
+    int "Inter-transmission sleep in seconds"
+    default 10
+    help
+	Time the sample sleeps between consecutive satellite packet
+	transmissions, in seconds.
+
+config SAMPLE_HUBBLE_KEY
+    string "Base64-encoded Hubble master key"
+    default ""
+    help
+	Base64-encoded master key provisioned at build time. Pass it with
+	west build ... -- -DCONFIG_SAMPLE_HUBBLE_KEY=\"<base64 key>\".
+	If left empty, an all-zero placeholder is used: the sample still
+	builds but will not produce valid advertisements until a real key
+	is supplied.
+
 endmenu
 
 source "Kconfig.zephyr"

--- a/samples/zephyr/sat-continuous/README.md
+++ b/samples/zephyr/sat-continuous/README.md
@@ -1,0 +1,107 @@
+# Hubble Network Satellite Continuous Sample
+
+This sample continuously builds Hubble satellite packets and transmits them in a
+loop. Use it as a starting point for satellite (space) connectivity on a
+supported radio.
+
+The sample uses the **device uptime** counter source
+(`CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME`), so it does not need UTC time
+provisioned: the EID counter used for encryption starts at 0 and advances with
+device uptime. Only the master key has to be embedded before building.
+
+> [!NOTE]
+> Satellite functionality is pre-production and not yet ready for production
+> deployments.
+
+## Requirements
+
+- A cryptographic key provided by Hubble Network.
+- A supported satellite-capable board (see [Supported boards](#supported-boards)).
+- For Nordic and Silicon Labs targets: the prebuilt radio blob (see
+  [Radio blobs](#radio-blobs)).
+
+## Radio blobs
+
+The satellite radio implementation for Nordic SoCs ships as a prebuilt static
+library (a "blob") rather than source. These are **not** fetched by
+`west update`; you must pull them in explicitly once after setting up the
+workspace:
+
+```sh
+west blobs fetch hubblenetwork-sdk
+```
+
+This downloads the satellite libraries for the nRF52/nRF53/nRF54 families into
+the module's `zephyr/blobs/` directory. If the blob for your target is missing,
+the build fails to link the satellite radio. Run `west blobs list
+hubblenetwork-sdk` to see what is available and whether it has been fetched.
+
+Silicon Labs targets (`xg24_rb4187c`, `xiao_mg24`) use the in-tree Gecko custom
+radio PHY (`CONFIG_SOC_GECKO_CUSTOM_RADIO_PHY`), but that PHY links against
+Silicon Labs' RAIL library, which is itself distributed as a blob. Fetch it once
+before building for those boards:
+
+```sh
+west blobs fetch hal_silabs
+```
+
+## Building and running
+
+Pass your base64 master key (the string Hubble gave you, already base64) on the
+build command line with `-DCONFIG_SAMPLE_HUBBLE_KEY`. The string is embedded in the firmware
+and decoded into the master key on startup using Zephyr's `base64_decode`, so
+there is no pre-build script and no generated source.
+
+```sh
+west blobs fetch hubblenetwork-sdk    # once, for Nordic targets
+west build -b nrf54l15dk/nrf54l15/cpuapp . -- -DCONFIG_SAMPLE_HUBBLE_KEY="<your base64 key>"
+west flash
+```
+
+After flashing, the device builds a satellite packet and transmits it every
+`CONFIG_SAMPLE_SAT_TX_INTERVAL_SECONDS` seconds (10 by default).
+
+> [!NOTE]
+> The decoded key length must match `CONFIG_HUBBLE_KEY_SIZE` (32 bytes for a
+> 256-bit key, 16 for 128-bit). A wrong or wrong-size key is rejected at startup
+> with a logged error and the sample exits; if `-DCONFIG_SAMPLE_HUBBLE_KEY` is omitted the
+> firmware uses an all-zero placeholder (with a warning) so it still builds and
+> runs in CI.
+
+> [!TIP]
+> `-DCONFIG_SAMPLE_HUBBLE_KEY` is cached in the build directory, so subsequent incremental
+> `west build` runs reuse it without repeating the flag. Pass it again (or use
+> `-p always`) to change the key.
+
+## Supported boards
+
+A board is wired up by providing a `boards/<board>.conf` (and optionally an
+overlay). Boards that supply their own satellite radio support set
+`CONFIG_SAMPLE_PROVIDE_SAT_BOARD_SUPPORT=n`; otherwise the sample mocks the
+board radio APIs so it still builds (e.g. on `native_sim`).
+
+| Board | Notes |
+|-------|-------|
+| `nrf54l15dk/nrf54l15/cpuapp` | Nordic nRF54L15 — needs the nRF54 blob |
+| `nrf21540dk` | Nordic nRF52840 + FEM — needs the nRF52 blob |
+| `thingy53/nrf5340/cpunet` | Nordic nRF5340 net core — needs the nRF53 blob |
+| `xg24_rb4187c` | Silicon Labs xG24 — uses the Gecko custom radio PHY |
+| `xiao_mg24` | Seeed XIAO MG24 — uses the Gecko custom radio PHY |
+
+## Configuration
+
+- `-DCONFIG_SAMPLE_HUBBLE_KEY`: the base64-encoded Hubble master key, embedded at build time
+  and decoded on the device at startup (see
+  [Building and running](#building-and-running)).
+- `CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME`: use the device uptime counter
+  source for EID/encryption so no UTC time provisioning is required (enabled in
+  `prj.conf`).
+- `CONFIG_HUBBLE_NETWORK_SECURITY_ENFORCE_NONCE_CHECK`: nonce-reuse enforcement,
+  which persists the sequence counter to NVS and rejects reused/decreasing
+  counters. Disabled (`n`) in `prj.conf` for this sample, which transmits
+  continuously and needs no NVS.
+- `CONFIG_SAMPLE_SAT_TX_INTERVAL_SECONDS`: seconds the sample sleeps between
+  consecutive satellite transmissions (default `5`).
+- `CONFIG_SAMPLE_PROVIDE_SAT_BOARD_SUPPORT`: when `n`, the board provides real
+  satellite radio support; when `y` (default), the sample mocks the board radio
+  APIs.

--- a/samples/zephyr/sat-continuous/prj.conf
+++ b/samples/zephyr/sat-continuous/prj.conf
@@ -3,4 +3,21 @@
 
 # Hubble Network
 CONFIG_HUBBLE_SAT_NETWORK=y
+
+# Decode the base64 master key (passed via -DHUBBLE_KEY) on the device.
+CONFIG_BASE64=y
+
+# Logging, so the key-provisioning warning/error and other status are visible.
+CONFIG_LOG=y
+
+# Use the device uptime counter source so the device does not need UTC time
+# provisioned. The EID counter starts from the value passed to hubble_init()
+# and advances with uptime.
+CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME=y
+
+# Disable nonce-reuse enforcement for this sample. The check persists the
+# sequence counter to NVS and rejects reused/decreasing counters; this sample
+# transmits continuously and needs no NVS, so turn it off.
+CONFIG_HUBBLE_NETWORK_SECURITY_ENFORCE_NONCE_CHECK=n
+
 CONFIG_MAIN_STACK_SIZE=2048

--- a/samples/zephyr/sat-continuous/src/main.c
+++ b/samples/zephyr/sat-continuous/src/main.c
@@ -8,15 +8,50 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/base64.h>
 
+#include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 LOG_MODULE_REGISTER(main);
 
-/* Replace it properly for real use */
-static uint64_t _unix_time_unused = 0xdeadbeef;
-static uint8_t _key_unused[CONFIG_HUBBLE_KEY_SIZE];
+/*
+ * Decoded master key. The SDK stores this pointer directly, so the buffer has
+ * static storage duration and outlives all SDK calls. Zero-initialised, which
+ * also serves as the all-zero placeholder when no key is provided.
+ */
+static uint8_t master_key[CONFIG_HUBBLE_KEY_SIZE];
+
+/*
+ * Decode the base64 master key (CONFIG_SAMPLE_HUBBLE_KEY, provisioned at build
+ * time) into master_key, validating its length.
+ */
+static int master_key_provision(void)
+{
+	const char *key = CONFIG_SAMPLE_HUBBLE_KEY;
+	size_t olen;
+	int err;
+
+	if (strlen(key) == 0) {
+		LOG_WRN("CONFIG_SAMPLE_HUBBLE_KEY not set; using an all-zero "
+			"placeholder key. Pass your base64 key with "
+			"-DCONFIG_SAMPLE_HUBBLE_KEY=\"<key>\".");
+		return 0;
+	}
+
+	err = base64_decode(master_key, sizeof(master_key), &olen, key,
+			    strlen(key));
+	if (err != 0 || olen != sizeof(master_key)) {
+		LOG_ERR("Invalid CONFIG_SAMPLE_HUBBLE_KEY: expected a base64-"
+			"encoded %u-byte key (matching CONFIG_HUBBLE_KEY_SIZE)",
+			(unsigned int)sizeof(master_key));
+		return -EINVAL;
+	}
+
+	return 0;
+}
 
 #ifdef CONFIG_SAMPLE_PROVIDE_SAT_BOARD_SUPPORT
 
@@ -52,7 +87,17 @@ int main(void)
 
 	LOG_DBG("Hubble Network Sat Sample started");
 
-	err = hubble_init(_unix_time_unused, _key_unused);
+	err = master_key_provision();
+	if (err != 0) {
+		goto end;
+	}
+
+	/*
+	 * This sample uses the device uptime counter source
+	 * (CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME), so no UTC time is needed:
+	 * we pass 0 as the initial EID counter value and it advances with uptime.
+	 */
+	err = hubble_init(0, master_key);
 	if (err != 0) {
 		LOG_ERR("Failed to initialize Hubble Sat Network");
 		goto end;
@@ -65,13 +110,17 @@ int main(void)
 			goto end;
 		}
 
-		err = hubble_sat_packet_send(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL);
+		/* Set reliability to NONE - this will trigger a single
+		 * transmission instead of a sequence. This is only for testing
+		 * purposes and not recommended for production.
+		 */
+		err = hubble_sat_packet_send(&pkt, HUBBLE_SAT_RELIABILITY_NONE);
 		if (err != 0) {
 			LOG_ERR("Failed to transmit packet");
 			goto end;
 		}
 
-		k_sleep(K_SECONDS(2));
+		k_sleep(K_SECONDS(CONFIG_SAMPLE_SAT_TX_INTERVAL_SECONDS));
 	}
 
 end:


### PR DESCRIPTION
Adds a real provisioning path to the `sat-continuous` sample, mirroring `ble-beacon-mfg-data`.

- **Build-time key**: pass the base64 master key via `-DHUBBLE_KEY`; decoded into a byte array at configure time (no base64 in firmware). All-zero placeholder + warning if omitted so CI still builds.
- **Encryption counter**: switch to the device uptime counter source (`CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME`), so no UTC provisioning needed.
- **Nonce check**: disabled for this sample (continuous TX, no NVS).
- **TX interval**: new `CONFIG_SAMPLE_SAT_TX_INTERVAL_SECONDS` Kconfig (default 5s), used in `main.c`.
- **README**: usage docs, including the `west blobs fetch hubblenetwork-sdk` step required for Nordic radios.