### PR TITLE
sat: zephyr/nrf: Use CONFIG_SOC_COMPATIBLE_NRF54LX

### DIFF
--- a/port/zephyr/boards/nordic/CMakeLists.txt
+++ b/port/zephyr/boards/nordic/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_NRF52 nrf52)
-add_subdirectory_ifdef(CONFIG_SOC_COMPATIBLE_NRF54L15 nrf54)
+add_subdirectory_ifdef(CONFIG_SOC_COMPATIBLE_NRF54LX nrf54)
 add_subdirectory_ifdef(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET nrf53)
 
 if(CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE)


### PR DESCRIPTION
Use CONFIG_SOC_COMPATIBLE_NRF54LX instead of
CONFIG_SOC_COMPATIBLE_NRF54L15 because older versions of Zephyr and NCS select this symbol only for bsim target.