### PR TITLE
api: use milliseconds for satellite pass prediction times

### DIFF
--- a/include/hubble/sat/pass_prediction.h
+++ b/include/hubble/sat/pass_prediction.h
@@ -100,11 +100,11 @@ struct hubble_sat_pass_info {
 	double lon;
 	/** Maximum elevation angle of the satellite above the horizon at culmination (degrees). */
 	double max_elevation_angle;
-	/** Pass start time (Unix time, seconds since epoch). */
+	/** Pass start time (Unix time, milliseconds since epoch). */
 	uint64_t start;
-	/** Time the satellite reaches culmination (Unix time, seconds since epoch). */
+	/** Time the satellite reaches culmination (Unix time, milliseconds since epoch). */
 	uint64_t culmination;
-	/** Time duration of the pass in seconds. */
+	/** Time duration of the pass in milliseconds. */
 	uint32_t duration;
 };
 
@@ -137,7 +137,7 @@ int hubble_sat_satellites_set(
  * given location, based on satellites orbital parameters
  * and the device's location.
  *
- * @param t Current time or the time to start the calculation (seconds since Unix epoch).
+ * @param t Current time or the time to start the calculation (milliseconds since Unix epoch).
  * @param pos Pointer to the device's location.
  * @param pass The next satellite pass in case of success.
  * @return 0 on success or a negative value in case of error.
@@ -152,7 +152,7 @@ int hubble_sat_next_pass_get(uint64_t t, const struct hubble_sat_device_pos *pos
  * rectangular geographic region defined by latitude and longitude
  * bounds, based on satellites orbital parameters.
  *
- * @param t Current time or the time to start the calculation (seconds since Unix epoch).
+ * @param t Current time or the time to start the calculation (milliseconds since Unix epoch).
  * @param region Pointer to the geographic region definition.
  * @param pass The next satellite pass in case of success.
  * @return 0 on success or a negative value in case of error.

--- a/samples/freertos/ti/sat-dual-stack/src/main.c
+++ b/samples/freertos/ti/sat-dual-stack/src/main.c
@@ -35,6 +35,7 @@ icall_userCfg_t user0Cfg = BLE_USER_CFG;
 #include "app_ble.h"
 
 #define US_PER_SEC 1000000ULL
+#define US_PER_MS  1000ULL
 
 #pragma message(                                                               \
 	"Dummy key, replace with actual key by running ./embed_key_time.py -b b64key -d")
@@ -90,7 +91,7 @@ void *main_thread_entry(void *arg0)
 
 	struct hubble_sat_pass_info pass_info;
 	struct hubble_sat_packet packet;
-	uint64_t now_s;
+	uint64_t now_ms;
 	uint64_t sat_wait_us;
 	bStatus_t status;
 	int ret;
@@ -119,8 +120,8 @@ void *main_thread_entry(void *arg0)
 
 	for (;;) {
 		/* Calculate the next pass time */
-		now_s = hubble_time_get() / 1000U;
-		ret = hubble_sat_next_pass_get(now_s, &device_pos, &pass_info);
+		now_ms = hubble_time_get();
+		ret = hubble_sat_next_pass_get(now_ms, &device_pos, &pass_info);
 		if (ret != 0) {
 			Log_printf(Log_Dual_Stack, Log_ERROR,
 				   "Failed to get next pass info, err: %d", ret);
@@ -131,7 +132,7 @@ void *main_thread_entry(void *arg0)
 		 * If the pass start < current time, this means we're in a
 		 * middle of a pass. We can compute the next one
 		 */
-		if (pass_info.start <= now_s) {
+		if (pass_info.start <= now_ms) {
 			Log_printf(
 				Log_Dual_Stack,
 				Log_INFO, "Current pass is ongoing or in the past, search for next pass...");
@@ -154,10 +155,11 @@ void *main_thread_entry(void *arg0)
 		Log_printf(
 			Log_Dual_Stack,
 			Log_INFO, "Next pass at: %u (unix epoch seconds), max elevation angle: %.2f",
-			pass_info.start, pass_info.max_elevation_angle);
+			(uint32_t)(pass_info.start / 1000U),
+			pass_info.max_elevation_angle);
 
 		/* Schedule the pass */
-		sat_wait_us = (pass_info.start - now_s) * US_PER_SEC;
+		sat_wait_us = (pass_info.start - now_ms) * US_PER_MS;
 #endif
 
 		/*

--- a/samples/zephyr/sat-dual-stack/src/main.c
+++ b/samples/zephyr/sat-dual-stack/src/main.c
@@ -74,7 +74,7 @@ int main(void)
 {
 	struct hubble_sat_pass_info pass_info = {0};
 	struct hubble_sat_packet packet = {0};
-	uint64_t now_s;
+	uint64_t now_ms;
 	int err;
 
 	LOG_INF("Hubble Network dual-stack sample started");
@@ -121,9 +121,9 @@ int main(void)
 
 	for (;;) {
 		/* Compute the next satellite pass over the device location. */
-		now_s = hubble_time_get() / MSEC_PER_SEC;
+		now_ms = hubble_time_get();
 
-		err = hubble_sat_next_pass_get(now_s, &device_pos, &pass_info);
+		err = hubble_sat_next_pass_get(now_ms, &device_pos, &pass_info);
 		if (err != 0) {
 			LOG_ERR("Failed to get next pass info (err %d)", err);
 			return err;
@@ -133,7 +133,7 @@ int main(void)
 		 * A pass start in the past means we are in the middle of a
 		 * pass; compute the next one.
 		 */
-		if (pass_info.start <= now_s) {
+		if (pass_info.start <= now_ms) {
 			LOG_INF("Pass ongoing or in the past, finding next...");
 
 			err = hubble_sat_next_pass_get(
@@ -151,8 +151,8 @@ int main(void)
 		k_timer_start(&sat_timer, K_SECONDS(120), K_NO_WAIT);
 #else
 		LOG_INF("Next pass at %llu (unix epoch seconds)",
-			pass_info.start);
-		k_timer_start(&sat_timer, K_SECONDS(pass_info.start - now_s),
+			pass_info.start / MSEC_PER_SEC);
+		k_timer_start(&sat_timer, K_MSEC(pass_info.start - now_ms),
 			      K_NO_WAIT);
 #endif
 

--- a/src/hubble_sat_pass_prediction.c
+++ b/src/hubble_sat_pass_prediction.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 
 #include "hubble_priv.h"
+#include "utils/macros.h"
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -805,6 +806,16 @@ static int _next_pass_culmination_get(
 	return 0;
 }
 
+/* Scale the pass times from the seconds used by the orbital math to the
+ * milliseconds exposed by the public API.
+ */
+static void _pass_times_to_ms(struct hubble_sat_pass_info *pass)
+{
+	pass->start *= HUBBLE_MSEC_PER_SEC;
+	pass->culmination *= HUBBLE_MSEC_PER_SEC;
+	pass->duration *= HUBBLE_MSEC_PER_SEC;
+}
+
 int hubble_sat_next_pass_get(uint64_t t, const struct hubble_sat_device_pos *pos,
 			     struct hubble_sat_pass_info *pass)
 {
@@ -826,6 +837,9 @@ int hubble_sat_next_pass_get(uint64_t t, const struct hubble_sat_device_pos *pos
 				   "satellites configured");
 		return -ENOENT;
 	}
+
+	/* The orbital math operates in seconds. */
+	t /= HUBBLE_MSEC_PER_SEC;
 
 	HUBBLE_LOG_DEBUG("Searching next pass from t=%llu lat=%f lon=%f",
 			 (unsigned long long)t, pos->lat, pos->lon);
@@ -874,6 +888,9 @@ int hubble_sat_next_pass_get(uint64_t t, const struct hubble_sat_device_pos *pos
 	pass->max_elevation_angle =
 		_elevation_angle_get(pass->lon, pos->lat, pos->lon, alt);
 
+	/* Report times in milliseconds, matching the rest of the SDK. */
+	_pass_times_to_ms(pass);
+
 	HUBBLE_LOG_DEBUG("Next pass found: start=%llu culmination=%llu lon=%f "
 			 "ascending=%d max_elevation_angle=%f",
 			 (unsigned long long)pass->start,
@@ -908,6 +925,9 @@ int hubble_sat_next_pass_region_get(
 				   "satellites configured");
 		return -ENOENT;
 	}
+
+	/* The orbital math operates in seconds. */
+	t /= HUBBLE_MSEC_PER_SEC;
 
 	HUBBLE_LOG_DEBUG("Searching next pass for region t=%llu lat_mid=%f "
 			 "lon_mid=%f lat_range=%f lon_range=%f",
@@ -1032,6 +1052,9 @@ int hubble_sat_next_pass_region_get(
 	pass->culmination -= hubble_internal_time_drift_get() / 2000U;
 
 	pass->start = pass->culmination - (pass->duration / 2U);
+
+	/* Report times in milliseconds, matching the rest of the SDK. */
+	_pass_times_to_ms(pass);
 
 	HUBBLE_LOG_DEBUG("Next region pass found: start=%llu culmination=%llu "
 			 "lon=%f duration=%llu "

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -29,4 +29,6 @@
 
 #define HUBBLE_BITS_PER_BYTE 8U
 
+#define HUBBLE_MSEC_PER_SEC  1000U
+
 #endif /* SRC_UTILS_MACROS_H */

--- a/tests/zephyr/pass-prediction/src/main.c
+++ b/tests/zephyr/pass-prediction/src/main.c
@@ -15,6 +15,11 @@
  */
 #define TRANSMISSION_PERIOD_SINGLE_PACKET (160U)
 
+/* The pass prediction API exchanges times in milliseconds, while the golden
+ * values below are kept in seconds for readability. MSEC_PER_SEC comes from
+ * Zephyr's sys headers.
+ */
+
 struct test_result {
 	struct hubble_sat_device_pos pos;
 	uint64_t start_time;
@@ -126,13 +131,14 @@ ZTEST(satellite_pass_prediction_test, test_satellite_pass_prediction_calculation
 	zassert_equal(ret, 0, NULL);
 
 	for (uint16_t count = 0; count < ARRAY_SIZE(results); count++) {
-		ret = hubble_sat_next_pass_get(results[count].start_time,
-					       &(results[count].pos), &next_pass);
+		ret = hubble_sat_next_pass_get(
+			results[count].start_time * MSEC_PER_SEC,
+			&(results[count].pos), &next_pass);
 
 		zassert_equal(ret, 0, NULL);
 		zassert_within(next_pass.culmination,
-			       results[count].culmination_time,
-			       PASS_PREDICTION_DELTA);
+			       results[count].culmination_time * MSEC_PER_SEC,
+			       PASS_PREDICTION_DELTA * MSEC_PER_SEC);
 	}
 }
 
@@ -202,17 +208,19 @@ ZTEST(satellite_pass_prediction_test,
 
 	for (uint16_t count = 0; count < ARRAY_SIZE(region_results); count++) {
 		ret = hubble_sat_next_pass_region_get(
-			region_results[count].start_time,
+			region_results[count].start_time * MSEC_PER_SEC,
 			&(region_results[count].region), &next_pass);
 
 		zassert_equal(ret, 0, NULL);
-		zassert_within(next_pass.culmination,
-			       region_results[count].culmination_time,
-			       PASS_PREDICTION_DELTA);
+		zassert_within(
+			next_pass.culmination,
+			region_results[count].culmination_time * MSEC_PER_SEC,
+			PASS_PREDICTION_DELTA * MSEC_PER_SEC);
 		zassert_within(next_pass.duration,
-			       region_results[count].duration +
-				       TRANSMISSION_PERIOD_SINGLE_PACKET,
-			       PASS_PREDICTION_DELTA);
+			       (region_results[count].duration +
+				TRANSMISSION_PERIOD_SINGLE_PACKET) *
+				       MSEC_PER_SEC,
+			       PASS_PREDICTION_DELTA * MSEC_PER_SEC);
 	}
 }
 


### PR DESCRIPTION
The rest of the SDK exchanges time in milliseconds (uptime, time set, transmission period), so accepting and returning seconds here forced callers to special-case unit conversion around these APIs. Align the pass prediction API with that convention so all SDK time values share one unit.

This is a breaking change for integrators currently passing or reading seconds.