### PR TITLE
zephyr: blobs: Use commit hash for links

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -12,18 +12,18 @@ blobs:
     version: "0.9"
     description: NRF52 Satellite library
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/refs/heads/main/nrf52/libhubble_sat_nrf52.a
+    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/0bc5b68aba7ae60efade987b4f00f08856bc278e/nrf52/libhubble_sat_nrf52.a
   - path: nrf53/libhubble_sat_nrf53.a
     sha256: 47741489229823098cc515abdc6ee74aababdbfc68afba93f958fca4ba7e64e1
     type: lib
     version: "0.9"
     description: NRF53 Satellite library
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/refs/heads/main/nrf53/libhubble_sat_nrf53.a
+    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/0bc5b68aba7ae60efade987b4f00f08856bc278e/nrf53/libhubble_sat_nrf53.a
   - path: nrf54/libhubble_sat_nrf54.a
     sha256: 06e493f1db0f4c26e89caca8307cd09564731270a4f864572ae102893892d8ab
     type: lib
     version: "0.9"
     description: NRF54 Satellite library
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/refs/heads/main/nrf54/libhubble_sat_nrf54.a
+    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/0bc5b68aba7ae60efade987b4f00f08856bc278e/nrf54/libhubble_sat_nrf54.a


### PR DESCRIPTION
Use commit hash for blobs instead of branch name this gives permanent links and does not break if the path or the files change in the main branch.