### PR TITLE
zephyr: blobs: Select satellite library by float ABI

### DIFF
--- a/port/zephyr/CMakeLists.txt
+++ b/port/zephyr/CMakeLists.txt
@@ -23,6 +23,12 @@ if(CONFIG_HUBBLE_SAT_NETWORK)
 
 	# Boards
 	set(HUBBLE_BLOBS_DIR ${ZEPHYR_HUBBLENETWORK_SDK_MODULE_DIR}/zephyr/blobs/)
+	if(CONFIG_FPU)
+		set(HUBBLE_BLOBS_ABI hard)
+	else()
+		set(HUBBLE_BLOBS_ABI soft)
+	endif()
+
 	add_subdirectory_ifdef(CONFIG_SOC_COMPATIBLE_NRF boards/nordic)
 	add_subdirectory_ifdef(CONFIG_SOC_GECKO_HAS_RADIO boards/silabs/efr32)
 	zephyr_include_directories(.)

--- a/port/zephyr/boards/nordic/nrf52/CMakeLists.txt
+++ b/port/zephyr/boards/nordic/nrf52/CMakeLists.txt
@@ -7,7 +7,7 @@ zephyr_library_sources(nrf52_soc.c)
 
 add_library(libhubble_sat_nrf52 STATIC IMPORTED GLOBAL)
 set_target_properties(libhubble_sat_nrf52 PROPERTIES
-	IMPORTED_LOCATION ${HUBBLE_BLOBS_DIR}/nrf52/libhubble_sat_nrf52.a
+	IMPORTED_LOCATION ${HUBBLE_BLOBS_DIR}/nrf52/${HUBBLE_BLOBS_ABI}/libhubble_sat_nrf52.a
 )
 zephyr_link_libraries(libhubble_sat_nrf52)
 

--- a/port/zephyr/boards/nordic/nrf53/CMakeLists.txt
+++ b/port/zephyr/boards/nordic/nrf53/CMakeLists.txt
@@ -7,7 +7,7 @@ zephyr_library_sources(nrf53_soc.c)
 
 add_library(libhubble_sat_nrf53 STATIC IMPORTED GLOBAL)
 set_target_properties(libhubble_sat_nrf53 PROPERTIES
-	IMPORTED_LOCATION ${HUBBLE_BLOBS_DIR}/nrf53/libhubble_sat_nrf53.a
+	IMPORTED_LOCATION ${HUBBLE_BLOBS_DIR}/nrf53/${HUBBLE_BLOBS_ABI}/libhubble_sat_nrf53.a
 )
 zephyr_link_libraries(libhubble_sat_nrf53)
 

--- a/port/zephyr/boards/nordic/nrf54/CMakeLists.txt
+++ b/port/zephyr/boards/nordic/nrf54/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 add_library(libhubble_sat_nrf54 STATIC IMPORTED GLOBAL)
 set_target_properties(libhubble_sat_nrf54 PROPERTIES
-	IMPORTED_LOCATION ${HUBBLE_BLOBS_DIR}/nrf54/libhubble_sat_nrf54.a
+	IMPORTED_LOCATION ${HUBBLE_BLOBS_DIR}/nrf54/${HUBBLE_BLOBS_ABI}/libhubble_sat_nrf54.a
 )
 zephyr_link_libraries(libhubble_sat_nrf54)
 

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -6,24 +6,45 @@ build:
 
 
 blobs:
-  - path: nrf52/libhubble_sat_nrf52.a
+  - path: nrf52/soft/libhubble_sat_nrf52.a
     sha256: 1b961ef4580c7a0c54780419b624a2b5913ac4cea7173f85bb1ab04d50735d36
     type: lib
     version: "0.9"
     description: NRF52 Satellite library
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/0bc5b68aba7ae60efade987b4f00f08856bc278e/nrf52/libhubble_sat_nrf52.a
-  - path: nrf53/libhubble_sat_nrf53.a
+    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/2d2e79e6ef2b2e9cc9f37fb4bb6f0b91a1c0b1f7/nrf52/soft/libhubble_sat_nrf52.a
+  - path: nrf52/hard/libhubble_sat_nrf52.a
+    sha256: 0dbbaef0b888cccbd0a937c6b233aabf9744fcc95d4fbe2a5659ec1e4451c1b2
+    type: lib
+    version: "0.9"
+    description: NRF52 Satellite library
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/2d2e79e6ef2b2e9cc9f37fb4bb6f0b91a1c0b1f7/nrf52/hard/libhubble_sat_nrf52.a
+  - path: nrf53/soft/libhubble_sat_nrf53.a
     sha256: 47741489229823098cc515abdc6ee74aababdbfc68afba93f958fca4ba7e64e1
     type: lib
     version: "0.9"
     description: NRF53 Satellite library
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/0bc5b68aba7ae60efade987b4f00f08856bc278e/nrf53/libhubble_sat_nrf53.a
-  - path: nrf54/libhubble_sat_nrf54.a
+    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/2d2e79e6ef2b2e9cc9f37fb4bb6f0b91a1c0b1f7/nrf53/soft/libhubble_sat_nrf53.a
+  - path: nrf53/hard/libhubble_sat_nrf53.a
+    sha256: 461ed4afb82afd236ae85d7c242f46907c8788c8be31d25d91b1281a2b7d61b8
+    type: lib
+    version: "0.9"
+    description: NRF53 Satellite library
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/2d2e79e6ef2b2e9cc9f37fb4bb6f0b91a1c0b1f7/nrf53/hard/libhubble_sat_nrf53.a
+  - path: nrf54/soft/libhubble_sat_nrf54.a
     sha256: 06e493f1db0f4c26e89caca8307cd09564731270a4f864572ae102893892d8ab
     type: lib
     version: "0.9"
     description: NRF54 Satellite library
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/0bc5b68aba7ae60efade987b4f00f08856bc278e/nrf54/libhubble_sat_nrf54.a
+    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/2d2e79e6ef2b2e9cc9f37fb4bb6f0b91a1c0b1f7/nrf54/soft/libhubble_sat_nrf54.a
+  - path: nrf54/hard/libhubble_sat_nrf54.a
+    sha256: 9c29eb378716372cac41210e10b29fdd3d4c1795deb549935aaf6bd9695c3a83
+    type: lib
+    version: "0.9"
+    description: NRF54 Satellite library
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/HubbleNetwork/hubble-device-sdk-blobs/raw/2d2e79e6ef2b2e9cc9f37fb4bb6f0b91a1c0b1f7/nrf54/hard/libhubble_sat_nrf54.a


### PR DESCRIPTION
Nordic satellite blobs are now provided for both the hard- and soft-float ABIs. Pick the matching variant at build time based on CONFIG_FPU and load it from the new nrf5x/{hard,soft}/ blob layout.