### PR TITLE
API: Fix null argument handling in Hubble SDK APIs

### DIFF
--- a/src/hubble.c
+++ b/src/hubble.c
@@ -79,10 +79,12 @@ int hubble_init(uint64_t initial_time, const void *key)
 	}
 #endif
 
-	ret = hubble_key_set(key);
-	if (ret != 0) {
-		HUBBLE_LOG_WARNING("Failed to set key");
-		return ret;
+	if (key != NULL) {
+		ret = hubble_key_set(key);
+		if (ret != 0) {
+			HUBBLE_LOG_WARNING("Failed to set key");
+			return ret;
+		}
 	}
 
 #ifdef CONFIG_HUBBLE_SAT_NETWORK

--- a/src/hubble_sat_packet.c
+++ b/src/hubble_sat_packet.c
@@ -373,6 +373,10 @@ int hubble_sat_packet_frames_get(const struct hubble_sat_packet *packet,
 		return _ret;                                                   \
 	}
 
+	if ((packet == NULL) || (frames == NULL)) {
+		return -EINVAL;
+	}
+
 	/* Validate the packet length (which maps to the PHY payload size field)
 	 * before mutating any channel-hopping state or touching the output.
 	 */

--- a/src/hubble_sat_packet.c
+++ b/src/hubble_sat_packet.c
@@ -262,6 +262,10 @@ int hubble_sat_packet_get(struct hubble_sat_packet *packet, const void *payload,
 	uint32_t time_counter;
 	uint32_t eid;
 
+	if ((packet == NULL) || ((payload == NULL) && (length > 0))) {
+		return -EINVAL;
+	}
+
 	if (hubble_internal_key_get() == NULL) {
 		HUBBLE_LOG_WARNING("Key not set");
 		return -EINVAL;

--- a/tests/zephyr/sat-api/src/main.c
+++ b/tests/zephyr/sat-api/src/main.c
@@ -136,6 +136,14 @@ ZTEST(sat_test, test_packet)
 	err = hubble_sat_packet_get(&pkt, NULL, 0);
 	zassert_ok(err);
 
+	/* NULL packet is invalid */
+	err = hubble_sat_packet_get(NULL, NULL, 0);
+	zassert_not_ok(err);
+
+	/* NULL payload with invalid length must return error */
+	err = hubble_sat_packet_get(&pkt, NULL, 20);
+	zassert_not_ok(err);
+
 	err = hubble_sat_packet_get(&pkt, buffer, 1);
 
 	/* Available sizes are: 0, 4, 9 and 13 (HUBBLE_SAT_PAYLOAD_MAX) */

--- a/tests/zephyr/unit/ble-advertise/src/main.c
+++ b/tests/zephyr/unit/ble-advertise/src/main.c
@@ -113,6 +113,23 @@ ZTEST(ble_advertise_test, test_advertise_null_input_handling)
 		"NULL payload with non-zero length should return -EINVAL");
 }
 
+ZTEST(ble_advertise_test, test_init_allows_deferred_key_argument)
+{
+	int ret;
+	uint8_t output[TEST_ADV_BUFFER_SZ];
+	size_t output_len = sizeof(output);
+
+	ret = hubble_init(test_unix_time, NULL);
+	zassert_ok(ret, "hubble_init should allow NULL key argument");
+	test_seq_override = 0;
+
+	ret = hubble_key_set(test_key_primary);
+	zassert_ok(ret, "hubble_key_set failed");
+
+	ret = hubble_ble_advertise_get(NULL, 0, output, &output_len);
+	zassert_ok(ret, "advertise should use previously configured key");
+}
+
 ZTEST(ble_advertise_test, test_advertise_buffer_too_small)
 {
 	uint8_t payload[] = {0x01, 0x02, 0x03, 0x04, 0x05};


### PR DESCRIPTION
Fixes API behavior for documented nullable/invalid arguments.

- Allow hubble_init(..., NULL) so applications can initialize before setting the key with hubble_key_set().
- Return -EINVAL from hubble_sat_packet_get() for NULL packet pointers and invalid NULL payloads.
- Return -EINVAL from hubble_sat_packet_frames_get() for NULL packet or frames pointers.
