### PR TITLE
samples: ti: sat: Add option to provision key and time

### DIFF
--- a/samples/freertos/ti/sat-continuous/README.md
+++ b/samples/freertos/ti/sat-continuous/README.md
@@ -46,8 +46,17 @@ export TICLANG_ARMCOMPILER=/path/to/ti/ti-cgt-armllvm
 export SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR=/path/to/ti/simplelink_lowpower_f3_sdk
 export SYSCONFIG_TOOL=/path/to/ti/sysconfig/sysconfig_cli.sh
 ```
+2. **Provision Time and Key (Optional)**
 
-2. **Build the Project**
+The device's Hubble key must be baked into the firmware at build time. Use the
+*embed_key_time.py* script to generate the key in hex and time in Unix. The tool will generate
+`key.c` and `time.c` into your project's /src directory.
+
+```bash
+python ../../../../tools/embed_key_time.py --base64 <path-to-key> -o src
+```
+
+3. **Build the Project**
 
    Build the project using the provided *makefile*:
 
@@ -57,7 +66,7 @@ make -f cc2340r5.mk
 # or make -f cc2755p10.mk
 ```
 
-3. **Flash the Firmware**
+4. **Flash the Firmware**
 
    Flash the generated firmware (*sat-continuous.out*) onto the target device using your preferred flashing tool.
 

--- a/samples/freertos/ti/sat-continuous/cc2340r5.mk
+++ b/samples/freertos/ti/sat-continuous/cc2340r5.mk
@@ -57,6 +57,12 @@ LFLAGS += "-L$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source" \
     "-L$(TICLANG_ARMCOMPILER)/lib" \
     -llibc.a
 
+# check if key and time is generated
+generated_files = src/key.c src/time.c
+ifeq ($(words $(wildcard $(generated_files))),2)
+	CFLAGS += -DHUBBLE_KEY_TIME_SET
+endif
+
 all: $(BUILD_DIR) postbuild
 
 $(BUILD_DIR):

--- a/samples/freertos/ti/sat-continuous/cc2755p10.mk
+++ b/samples/freertos/ti/sat-continuous/cc2755p10.mk
@@ -62,6 +62,12 @@ LFLAGS += "-L$(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/source" \
     "-L$(TICLANG_ARMCOMPILER)/lib" \
     -llibc.a
 
+# check if key and time is generated
+generated_files = src/key.c src/time.c
+ifeq ($(words $(wildcard $(generated_files))),2)
+	CFLAGS += -DHUBBLE_KEY_TIME_SET
+endif
+
 all: $(BUILD_DIR) postbuild
 
 $(BUILD_DIR):

--- a/samples/freertos/ti/sat-continuous/src/main.c
+++ b/samples/freertos/ti/sat-continuous/src/main.c
@@ -23,15 +23,25 @@
 
 #define SLEEP_PERIOD_MS 1000
 
-static uint64_t _unix_time = 0xdeadbeef;
-static uint8_t _key_unused[CONFIG_HUBBLE_KEY_SIZE];
+#if defined(HUBBLE_KEY_TIME_SET)
+#include "key.c"
+#include "time.c"
+#else
+
+#pragma message(                                                               \
+	"Dummy key, replace with actual key by running ./embed_key_time.py -b b64key to set key and time")
+
+static uint8_t master_key[CONFIG_HUBBLE_KEY_SIZE];
+static uint64_t unix_time = 0xdeadbeef;
+
+#endif
 
 void *mainThread(void *arg0)
 {
 	struct hubble_sat_packet packet;
 	int ret;
 
-	ret = hubble_init(_unix_time, _key_unused);
+	ret = hubble_init(unix_time, master_key);
 	if (ret != 0) {
 		/* TODO: Call Error Handler */
 		return NULL;

--- a/samples/freertos/ti/sat-dual-stack/README.md
+++ b/samples/freertos/ti/sat-dual-stack/README.md
@@ -58,11 +58,11 @@ pip install -r ../../../../tools/requirements-companion.txt
 ### 2. Embed Device Key
 
 The device's Hubble key must be baked into the firmware at build time. Use the
-*embed_key_time.py* script to generate the key in hex, and copy that into
-`_hubble_key` array:
+*embed_key_time.py* script to generate the key in hex. The tool will generate
+`key.c` into your project's /src directory.
 
 ```bash
-python ../../../../tools/embed_key_time.py --base64 <path-to-key> -d
+python ../../../../tools/embed_key_time.py --base64 <path-to-key> -o src/
 ```
 
 ### 3. Build the Project

--- a/samples/freertos/ti/sat-dual-stack/cc2340r5.mk
+++ b/samples/freertos/ti/sat-dual-stack/cc2340r5.mk
@@ -111,6 +111,12 @@ LFLAGS += -Wl,--diag_wrap=off \
 	$(BUILD_DIR)/cc2340_freertos.cmd \
 	-llibc.a
 
+# check if key and time is generated
+generated_files = src/key.c
+ifeq ($(words $(wildcard $(generated_files))),1)
+	CFLAGS += -DHUBBLE_KEY_SET
+endif
+
 all: $(BUILD_DIR) postbuild
 
 $(BUILD_DIR):

--- a/samples/freertos/ti/sat-dual-stack/cc2755p10.mk
+++ b/samples/freertos/ti/sat-dual-stack/cc2755p10.mk
@@ -111,6 +111,12 @@ LFLAGS += -Wl,--diag_wrap=off \
 	$(BUILD_DIR)/cc27xx_freertos.cmd \
 	-llibc.a
 
+# check if key and time is generated
+generated_files = src/key.c
+ifeq ($(words $(wildcard $(generated_files))),1)
+	CFLAGS += -DHUBBLE_KEY_SET
+endif
+
 all: $(BUILD_DIR) postbuild
 
 $(BUILD_DIR):

--- a/samples/freertos/ti/sat-dual-stack/src/main.c
+++ b/samples/freertos/ti/sat-dual-stack/src/main.c
@@ -37,9 +37,12 @@ icall_userCfg_t user0Cfg = BLE_USER_CFG;
 #define US_PER_SEC 1000000ULL
 #define US_PER_MS  1000ULL
 
-#pragma message(                                                               \
-	"Dummy key, replace with actual key by running ./embed_key_time.py -b b64key -d")
-static uint8_t _hubble_key[CONFIG_HUBBLE_KEY_SIZE];
+#if defined(HUBBLE_KEY_SET)
+#include "key.c"
+#else
+#warning "Dummy key, replace with actual key by running ./embed_key_time.py -b b64key"
+static uint8_t master_key[CONFIG_HUBBLE_KEY_SIZE];
+#endif
 
 /* Time */
 uint64_t unix_time_ms;
@@ -245,7 +248,7 @@ int main()
 	 * work but you can not disable it.
 	 */
 	unix_time_ms = 0xdeadbeef;
-	ret = hubble_init(unix_time_ms, _hubble_key);
+	ret = hubble_init(unix_time_ms, master_key);
 	if (ret != 0) {
 		return ret;
 	}


### PR DESCRIPTION
- Add an option to use embed_key_time in the way already described in sat-dual-stack to provision key and time. for sat-dual-stack and sat-continuous
- Helpful for testing so we can detect packets with the correct device ID