### PR TITLE
fix: docs: fix code block format issue for freertos quickstart

### DIFF
--- a/docs/quickstart/freertos/index.rst
+++ b/docs/quickstart/freertos/index.rst
@@ -22,9 +22,9 @@ Adding Hubble Network to FreeRTOS
 
 * Include Hubble Network SDK in your application
 
-     .. code-block:: bash
+  .. code-block:: bash
 
-     git submodule add  https://github.com/HubbleNetwork/hubble-device-sdk .
+     git submodule add https://github.com/HubbleNetwork/hubble-device-sdk .
 
 
 * Provide a configuration header


### PR DESCRIPTION
The code should be indented from the code block directive, putting it in line result in an empty code block when rendered.