### PR TITLE
sat: zephy/nrf: Fix build symbol

### DIFF
--- a/port/zephyr/Kconfig.nrf
+++ b/port/zephyr/Kconfig.nrf
@@ -1,11 +1,16 @@
 # Copyright (c) 2026 Hubble Network, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_FAMILY_NORDIC_NRF && HUBBLE_SAT_NETWORK && HUBBLE_BLE_NETWORK
+if SOC_FAMILY_NORDIC_NRF
 
 if !ZEPHYR_NRF_MODULE
+
+if HUBBLE_SAT_NETWORK
+
 configdefault NRFX_TIMER
       	default y
+
+if HUBBLE_BLE_NETWORK
 
 configdefault BT_CTLR_ADVANCED_FEATURES
       	default y
@@ -22,6 +27,10 @@ configdefault DYNAMIC_DIRECT_INTERRUPTS
 configdefault SHARED_INTERRUPTS
       	default y
 
-endif # ZEPHYR_NRF_MODULE
+endif # HUBBLE_BLE_NETWORK
 
-endif # SOC_FAMILY_NORDIC_NRF && HUBBLE_SAT_NETWORK && HUBBLE_BLE_NETWORK
+endif # HUBBLE_SAT_NETWORK
+
+endif # !ZEPHYR_NRF_MODULE
+
+endif # SOC_FAMILY_NORDIC_NRF


### PR DESCRIPTION
NRFX_TIMER must be selected for satellite support even without dual-stack support.