### PR TITLE
port: ti: Automatically setup radio

### DIFF
--- a/.meta/Hubble.syscfg.js
+++ b/.meta/Hubble.syscfg.js
@@ -96,6 +96,11 @@ function getOpts(mod) {
         if (hubble.dtmMode) {
             result.push(`-DCONFIG_HUBBLE_SAT_NETWORK_DTM_MODE`);
         }
+
+        if (hubble.useFreeRTOSDaemonHook) {
+            result.push(`-DconfigUSE_DAEMON_TASK_STARTUP_HOOK`);
+            result.push(`-DCONFIG_HUBBLE_FREERTOS_DAEMON_HOOK`);
+        }
     }
 
     if (hubble.useTerrestrial) {
@@ -357,6 +362,17 @@ needed to verify time-dependent behavior.
 `,
                 default: false
             },
+            {
+                name: "useFreeRTOSDaemonHook",
+                displayName: "Use FreeRTOS Daemon Hook to init radio",
+                description: `
+Use FreeRTOS daemon task startup hook to automatically configure the device
+radio. If that is not set the application must call hubble_init() before using
+Bluetooth or the Hubble APIs.
+`,
+                default: true,
+                hidden: true
+            },
         ]
     },
     templates: {
@@ -377,6 +393,7 @@ function onUseSatelliteChange(inst, ui)
 {
     ui.deviceTDR.hidden = !inst.useSatellite;
     ui.dtmMode.hidden = !inst.useSatellite;
+    ui.useFreeRTOSDaemonHook.hidden = !inst.useSatellite;
 
     // reset so a stale "true" can't leak when sat is disabled
     if (!inst.useSatellite) {

--- a/docs/quickstart/ti/index.rst
+++ b/docs/quickstart/ti/index.rst
@@ -152,9 +152,12 @@ and the ``-DUSE_DMM*`` flags.
 
 .. important::
 
-   In a dual-stack application, :c:func:`hubble_init` must be called **before**
-   the BLE stack is started. ``hubble_init`` sets up both the BLE (BT) and the
-   custom RF stacks for satellite use.
+   In a dual-stack application, ``hubble_init`` sets up both the BLE (BT) and
+   the custom RF stacks for satellite use. It must be called **before** the BLE
+   stack is started **only when** ``CONFIG_HUBBLE_FREERTOS_DAEMON_HOOK``
+   (``configUSE_DAEMON_TASK_STARTUP_HOOK`` when using SysConfig) is disabled.
+   When the daemon task startup hook is enabled, :c:func:`hubble_init` has to
+   be invoked only before using Hubble SDK APIs.
 
 .. note::
 

--- a/port/freertos/boards/ti/cc23xx_cc27xx/radio.c
+++ b/port/freertos/boards/ti/cc23xx_cc27xx/radio.c
@@ -136,24 +136,9 @@ static int hubble_dmm_init(void)
 }
 #endif
 
-/* TODO: make sure that the init is only called once during a lifetime of the application */
-int hubble_sat_board_init(void)
+static inline int _board_init(void)
 {
 	int ret = 0;
-
-	_transmit_sem = xSemaphoreCreateBinary();
-	if (_transmit_sem == NULL) {
-		return -ENOMEM;
-	}
-
-	/* Make count to 1 initially */
-	if (xSemaphoreGive(_transmit_sem) != pdTRUE) {
-		vSemaphoreDelete(_transmit_sem);
-
-		_transmit_sem = NULL;
-
-		return -EAGAIN;
-	}
 
 #if defined(USE_DMM_OVRDE)
 	DMMSch_RCL_init();
@@ -169,7 +154,6 @@ int hubble_sat_board_init(void)
 #endif
 
 	if (rcl_handle == NULL) {
-		/* TODO: clean up the sem */
 		return -EIO;
 	}
 
@@ -191,6 +175,38 @@ int hubble_sat_board_init(void)
 	rclPacketTxCmdGenericTxTest_ble_custom.config.sendCw = 1U;
 
 	return ret;
+}
+
+#ifdef CONFIG_HUBBLE_FREERTOS_DAEMON_HOOK
+void vApplicationDaemonTaskStartupHook(void)
+{
+	(void)_board_init();
+}
+#endif
+
+/* TODO: make sure that the init is only called once during a lifetime of the application */
+int hubble_sat_board_init(void)
+{
+	_transmit_sem = xSemaphoreCreateBinary();
+	if (_transmit_sem == NULL) {
+		return -ENOMEM;
+	}
+
+	/* Make count to 1 initially */
+	if (xSemaphoreGive(_transmit_sem) != pdTRUE) {
+		vSemaphoreDelete(_transmit_sem);
+
+		_transmit_sem = NULL;
+
+		return -EAGAIN;
+	}
+
+#ifndef CONFIG_HUBBLE_FREERTOS_DAEMON_HOOK
+	return _board_init();
+#else
+	/* If the radio was properly configured, we must have a valid RCL handle here. */
+	return rcl_handle != NULL ? 0 : -EIO;
+#endif
 }
 
 int hubble_sat_board_enable(void)

--- a/port/freertos/config.h
+++ b/port/freertos/config.h
@@ -91,6 +91,24 @@
 #endif
 
 /*
+ * Initialize the radio via the FreeRTOS Timer/Daemon task startup hook
+ * (vApplicationDaemonTaskStartupHook). When enabled, board initialization
+ * runs at the start of the timer task — after the scheduler is running but
+ * before any timer callbacks fire — which satisfies the RCL driver requirement
+ * that RCL_init / RCL_open are called from a task context. Also enables
+ * configUSE_DAEMON_TASK_STARTUP_HOOK so FreeRTOS calls the hook.
+ *
+ * When disabled, the application must call hubble_sat_board_init() from a
+ * task context itself before using satellite network or Bluetooth functionality.
+ *
+ * Default: enabled when CONFIG_HUBBLE_SAT_NETWORK is defined.
+ */
+#ifndef CONFIG_HUBBLE_FREERTOS_DAEMON_HOOK
+#define CONFIG_HUBBLE_FREERTOS_DAEMON_HOOK 1
+#define configUSE_DAEMON_TASK_STARTUP_HOOK
+#endif
+
+/*
  * DTM Mode
  * Enable DTM (Direct Test Mode) in the SDK, this is intended
  * to test the operation of the radio.

--- a/samples/freertos/ti/sat-dual-stack/src/app_ble.c
+++ b/samples/freertos/ti/sat-dual-stack/src/app_ble.c
@@ -287,7 +287,6 @@ static void _conn_event_handler(uint32 event, BLEAppUtil_msgHdr_t *pMsg)
 		Log_printf(Log_Dual_Stack, Log_DEBUG, "Disconnected");
 
 		if (unix_time_ms != 0) {
-			(void)hubble_time_set(unix_time_ms);
 			SemaphoreP_post(_sync_sem_handle);
 
 		} else {

--- a/samples/freertos/ti/sat-dual-stack/src/main.c
+++ b/samples/freertos/ti/sat-dual-stack/src/main.c
@@ -45,7 +45,7 @@ static uint8_t master_key[CONFIG_HUBBLE_KEY_SIZE];
 #endif
 
 /* Time */
-uint64_t unix_time_ms;
+uint64_t unix_time_ms = 0;
 
 /* Device location and sat orbital paramters */
 struct hubble_sat_device_pos device_pos;
@@ -109,6 +109,13 @@ void *main_thread_entry(void *arg0)
 		Log_printf(Log_Dual_Stack, Log_ERROR,
 			   "Failed to sync time and orbital params, err: %d",
 			   status);
+		return NULL;
+	}
+
+	ret = hubble_init(unix_time_ms, master_key);
+	if (ret != 0) {
+		Log_printf(Log_Dual_Stack, Log_ERROR,
+			   "Failed to init Hubble SDK");
 		return NULL;
 	}
 
@@ -241,20 +248,6 @@ int main()
 	if (_sat_timer_handle == NULL) {
 		return -ENODEV;
 	}
-
-	/* TODO:
-	 * hubble init MUST be called first before starting the BLE stack
-	 * because it set up both the BT and customRF stacks. Otherwise, BT will
-	 * work but you can not disable it.
-	 */
-	unix_time_ms = 0xdeadbeef;
-	ret = hubble_init(unix_time_ms, master_key);
-	if (ret != 0) {
-		return ret;
-	}
-
-	/* Part of the workaround so time sync works correctlys */
-	unix_time_ms = 0U;
 
 	/* Update User Configuration of the stack */
 	user0Cfg.appServiceInfo->timerTickPeriod = ICall_getTickPeriod();


### PR DESCRIPTION
Add a build option that automatically sets up the radio.
If the application needs to use this FreeRTOS hook it can
disable the option but it needs to call hubble_init()
before using Bluetooth or Hubble stacks.
