### PR TITLE
samples: ti/sat-dtm: fix misc issues

### DIFF
--- a/samples/freertos/ti/sat-dtm/src/hubble_ti_crypto.c
+++ b/samples/freertos/ti/sat-dtm/src/hubble_ti_crypto.c
@@ -31,6 +31,7 @@ int hubble_crypto_aes_ctr(const uint8_t key[CONFIG_HUBBLE_KEY_SIZE],
 			  uint8_t nonce_counter[HUBBLE_NONCE_BUFFER_SIZE],
 			  const uint8_t *data, size_t len, uint8_t *output)
 {
+	memcpy(output, data, len);
 	return 0;
 }
 

--- a/samples/freertos/ti/sat-dtm/src/main.c
+++ b/samples/freertos/ti/sat-dtm/src/main.c
@@ -20,7 +20,7 @@
 extern void *main_thread(void *arg0);
 
 /* Stack size in bytes */
-#define THREADSTACKSIZE 1024
+#define THREADSTACKSIZE 2048
 
 int main(void)
 {


### PR DESCRIPTION
- Fix single transmit calls cause stack overflow.
- Fix transmit random bytes instead of all 0 bytes.