### PR TITLE
docs: improvements: Names and organization

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,7 +9,7 @@ body:
   - type: input
     id: sdk-version
     attributes:
-      label: Hubble Network  SDK Commit Hash
+      label: Hubble Device SDK Commit Hash
       description: >-
         Run `git show HEAD -s --format='%H'` in your repository
     validations:

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The Hubble Network SDK project supports the following versions with security
+The Hubble Device SDK project supports the following versions with security
 updates:
 
   - The most recent release, and the release prior to that.
@@ -12,6 +12,6 @@ updates:
 
 Vulnerabilities in the Hubble Network platform may be reported via
 email to the security@hubble.com mailing list or directly in
-[Hubble Network SDK advisories](https://github.com/HubbleNetwork/hubble-device-sdk/security/advisories)
+[Hubble Device SDK advisories](https://github.com/HubbleNetwork/hubble-device-sdk/security/advisories)
 
 For additional information see [Hubble Network vulnerability handling](https://docs.hubblenetwork.com/docs/device-sdk/vulnerability-handling).

--- a/.meta/Hubble.component.js
+++ b/.meta/Hubble.component.js
@@ -8,8 +8,8 @@
 
 let topModules;
 
-const displayName = "Hubble Network SDK";
-const description = "Hubble Network SDK Options";
+const displayName = "Hubble Device SDK";
+const description = "Hubble Device SDK Options";
 
 topModules = [
     {

--- a/.meta/Hubble.syscfg.js
+++ b/.meta/Hubble.syscfg.js
@@ -6,8 +6,8 @@
 
 "use strict";
 
-const topModuleDisplayName = "Hubble Network SDK";
-const topModuleDescription = "Hubble Network SDK Configuration";
+const topModuleDisplayName = "Hubble Device SDK";
+const topModuleDescription = "Hubble Device SDK Configuration";
 
 function validate(mod, validation)
 {
@@ -59,7 +59,7 @@ var cc27xxDMMDeviceFiles = [
 
 function getSDKRootDir()
 {
-    const product = system.getProducts().find(p => p.name == "Hubble Network SDK");
+    const product = system.getProducts().find(p => p.name == "Hubble Device SDK");
     if (product) {
         let sdkPath = system.utils.path.parse(
             system.utils.path.parse(product.path).dir

--- a/.metadata/product.json
+++ b/.metadata/product.json
@@ -1,7 +1,7 @@
 {
-    "name": "Hubble Network SDK",
+    "name": "Hubble Device SDK",
     "version": "2.0.0",
-    "displayName": "Hubble SDK",
+    "displayName": "Hubble Device SDK",
     "includePaths": [
         "../"
     ],

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Hubble Network SDK community is composed of developers,
+The Hubble Device SDK community is composed of developers,
 researchers, enthusiasts, and contributors from around the world. We
 are all collaborating to build an innovative ecosystem around
 space-based connectivity and low-power embedded systems.
@@ -91,7 +91,7 @@ Include (if possible):
 * Names or usernames of people involved
 * Whether this is ongoing
 
-Reports sent to this address are accessible only to the Hubble Network
+Reports sent to this address are accessible only to the Hubble Device
 SDK maintainers responsible for community management. Information
 shared will not be disclosed publicly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to Hubble Network SDK
+# Contributing to Hubble Device SDK
 
-Thank you for your interest in contributing to the Hubble Network SDK.
+Thank you for your interest in contributing to the Hubble Device SDK.
 
-This document outlines the contribution guidelines and processes for the Hubble Network
+This document outlines the contribution guidelines and processes for the Hubble Device
 SDK. Following these guidelines helps ensure consistency, quality, and maintainability
 across the codebase while facilitating collaboration among contributors.
 
@@ -16,7 +16,7 @@ uphold this code. Please report unacceptable behavior to support@hubble.com.
 
 Before asking a question:
 
-- Check the [Hubble Network SDK Documentation](https://docs.hubble.com/docs/device-sdk/intro)
+- Check the [Hubble Device SDK Documentation](https://docs.hubble.com/docs/device-sdk/intro)
 - Search existing [Issues](https://github.com/hubblenetwork/hubble-device-sdk/issues)
 - Review the codebase and examples in the `samples/` directory
 
@@ -55,7 +55,7 @@ your `user.name` and `user.email` in git.
 
 ### License
 
-The Hubble Network SDK uses the Apache 2.0 license. All contributions must be
+The Hubble Device SDK uses the Apache 2.0 license. All contributions must be
 compatible with this license. Each source file must include the SPDX license
 identifier:
 
@@ -360,4 +360,4 @@ If you have questions about contributing, please:
 - Review the [documentation](https://docs.hubble.com/docs/device-sdk/intro)
 - Start a new discussion in [GitHub Discussions](https://github.com/hubblenetwork/hubble-device-sdk/discussions)
 
-Thank you for contributing to the Hubble Network SDK! 🚀
+Thank you for contributing to the Hubble Device SDK! 🚀

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -44,7 +44,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Hubble Network SDK API documentation"
+PROJECT_NAME           = "Hubble Device SDK API documentation"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/docs/api/ble.rst
+++ b/docs/api/ble.rst
@@ -4,5 +4,5 @@ BLE Network API
 ###############
 
 .. doxygengroup:: hubble_ble_api
-   :project: HubbleNetworkSDK
+   :project: Hubble Device SDK
    :members:

--- a/docs/api/ble.rst
+++ b/docs/api/ble.rst
@@ -1,0 +1,8 @@
+.. _hubble_ble_api:
+
+BLE Network API
+###############
+
+.. doxygengroup:: hubble_ble_api
+   :project: HubbleNetworkSDK
+   :members:

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -4,14 +4,14 @@ Core API
 ########
 
 The core API provides the initialization, time, and key-management functions
-shared by every Hubble Network SDK network.
+shared by every Hubble Device SDK network.
 
 .. doxygengroup:: hubble_api
-   :project: HubbleNetworkSDK
+   :project: Hubble Device SDK
    :members:
 
 .. _hubble_crypto:
 
 .. doxygengroup:: hubble_crypto
-   :project: HubbleNetworkSDK
+   :project: Hubble Device SDK
    :members:

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -1,10 +1,10 @@
-.. _hubble_ble_api:
+.. _hubble_core_api:
 
-BLE Network API Reference
-#########################
+Core API
+########
 
-.. doxygengroup:: hubble_ble_api
-   :project: HubbleNetworkSDK
+The core API provides the initialization, time, and key-management functions
+shared by every Hubble Network SDK network.
 
 .. doxygengroup:: hubble_api
    :project: HubbleNetworkSDK
@@ -15,4 +15,3 @@ BLE Network API Reference
 .. doxygengroup:: hubble_crypto
    :project: HubbleNetworkSDK
    :members:
-

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -3,7 +3,7 @@
 API
 ###
 
-Doxygen-generated API reference for the Hubble Network SDK, grouped by network.
+Doxygen-generated API reference for the Hubble Device SDK, grouped by network.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,13 @@
+.. _hubble_api_reference:
+
+API
+###
+
+Doxygen-generated API reference for the Hubble Network SDK, grouped by network.
+
+.. toctree::
+   :maxdepth: 1
+
+   core
+   ble
+   satellite

--- a/docs/api/satellite.rst
+++ b/docs/api/satellite.rst
@@ -7,16 +7,16 @@ Application APIs
 ****************
 
 .. doxygengroup:: hubble_sat_api
-   :project: HubbleNetworkSDK
+   :project: Hubble Device SDK
    :members:
 
 .. doxygengroup:: hubble_sat_packet_api
-   :project: HubbleNetworkSDK
+   :project: Hubble Device SDK
    :members:
 
 Port APIs
 *********
 
 .. doxygengroup:: hubble_sat_radio_port
-   :project: HubbleNetworkSDK
+   :project: Hubble Device SDK
    :members:

--- a/docs/api/satellite.rst
+++ b/docs/api/satellite.rst
@@ -1,16 +1,22 @@
 .. _hubble_sat_api:
 
+Satellite Network API
+#####################
+
 Application APIs
-################
+****************
 
 .. doxygengroup:: hubble_sat_api
    :project: HubbleNetworkSDK
+   :members:
 
 .. doxygengroup:: hubble_sat_packet_api
    :project: HubbleNetworkSDK
+   :members:
 
 Port APIs
-#########
+*********
 
 .. doxygengroup:: hubble_sat_radio_port
    :project: HubbleNetworkSDK
+   :members:

--- a/docs/architecture/index.rst
+++ b/docs/architecture/index.rst
@@ -5,13 +5,13 @@ Architecture
 
 The SDK architecture is built on modularity and extensibility, accommodating
 a broad range of implementation requirements. The diagram below illustrates the
-role of the Hubble Network SDK within an embedded application:
+role of the Hubble Device SDK within an embedded application:
 
 .. figure:: images/sdk-architecture.svg
-   :alt: Hubble Network SDK
+   :alt: Hubble Device SDK
    :align: center
 
-   Hubble Network SDK Architecture
+   Hubble Device SDK Architecture
 
 The following sections summarize its primary components.
 

--- a/docs/architecture/project-organization.rst
+++ b/docs/architecture/project-organization.rst
@@ -3,7 +3,7 @@
 Project Organization
 ####################
 
-The Hubble Network SDK is organized around a small common core, public headers,
+The Hubble Device SDK is organized around a small common core, public headers,
 and platform-specific ports. The common code implements the SDK protocols and
 state management. The port code adapts those protocols to a specific RTOS,
 crypto provider, radio driver, and board.

--- a/docs/best-practices/index.rst
+++ b/docs/best-practices/index.rst
@@ -4,7 +4,7 @@ Best Practices
 ##############
 
 Practical guidance for building reliable applications on top of the Hubble
-Network SDK. These recommendations apply across every supported network — both
+Device SDK. These recommendations apply across every supported network — both
 the BLE (Terrestrial) Network and the Satellite Network.
 
 .. toctree::

--- a/docs/best-practices/index.rst
+++ b/docs/best-practices/index.rst
@@ -1,0 +1,13 @@
+.. _hubble_best_practices:
+
+Best Practices
+##############
+
+Practical guidance for building reliable applications on top of the Hubble
+Network SDK. These recommendations apply across every supported network — both
+the BLE (Terrestrial) Network and the Satellite Network.
+
+.. toctree::
+   :maxdepth: 1
+
+   time-management

--- a/docs/best-practices/time-management.rst
+++ b/docs/best-practices/time-management.rst
@@ -1,7 +1,7 @@
 .. _hubble_timing:
 
-Best Practices for Time Management
-##################################
+Time Management
+###############
 
 Proper time management is critical for ensuring accurate encryption
 and secure operations in the SDK. Below are the best practices for

--- a/docs/ble/index.rst
+++ b/docs/ble/index.rst
@@ -29,7 +29,8 @@ Time Synchronization
 
 Functions are available to initialize the network with the current time and
 update it as needed. This ensures that all nodes remain synchronized, which
-facilitates coordinated operations and data consistency.
+facilitates coordinated operations and data consistency. See :ref:`hubble_timing`
+for best practices on provisioning time and accounting for clock drift.
 
 Advertisement Management
 ------------------------
@@ -86,24 +87,6 @@ interaction within the network:
 .. code-block:: c
 
    int hubble_ble_advertise_get(const uint8_t *input, size_t input_len, uint8_t *out, size_t *out_len);
-
-Security Details
-****************
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   security.rst
-
-Timing management
-*****************
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   timing.rst
 
 API Reference
 *************

--- a/docs/ble/index.rst
+++ b/docs/ble/index.rst
@@ -88,11 +88,4 @@ interaction within the network:
 
    int hubble_ble_advertise_get(const uint8_t *input, size_t input_len, uint8_t *out, size_t *out_len);
 
-API Reference
-*************
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   api.rst
+The full API is documented in the :ref:`hubble_ble_api` reference.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# Hubble Network SDK build configuration file.
+# Hubble Device SDK build configuration file.
 #
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
@@ -8,7 +8,7 @@ from pathlib import Path
 
 # -- Project information -----------------------------------------------------
 
-project = "Hubble Network SDK"
+project = "Hubble Device SDK"
 copyright = "2025, Hubble Network, Inc"
 author = "HubbleNetwork"
 release = "0.1"
@@ -42,8 +42,8 @@ templates_path = ["templates"]
 exclude_patterns = []
 
 # Setup the breathe extension
-breathe_projects = {"HubbleNetworkSDK": "./_doxygen/xml"}
-breathe_default_project = "HubbleNetworkSDK"
+breathe_projects = {"Hubble Device SDK": "./_doxygen/xml"}
+breathe_default_project = "Hubble Device SDK"
 
 # Tell sphinx what the primary language being documented is.
 primary_domain = "c"
@@ -60,7 +60,7 @@ toc_object_entries = False
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
-html_title = "Hubble Network SDK Documentation"
+html_title = "Hubble Device SDK Documentation"
 html_logo = "static/images/hubble-logo.svg"
 html_favicon = "static/images/hubble.png"
 html_split_index = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,25 @@ html_context = {
 }
 
 
+def _fix_breathe_toc_entries(app, doctree):
+    # Since Breathe 4.36.0 setting toc_object_entries to False
+    # is not enough to not have APIs functions appearing in the sidebar.
+    # Breathe unconditionally sets _toc_name/_toc_parts on desc_signature nodes,
+    # bypassing Sphinx's toc_object_entries check. Clear them here so that
+    # toc_object_entries = False actually suppresses API functions from the sidebar.
+    if app.config.toc_object_entries:
+        return
+
+    from sphinx import addnodes
+
+    for sig in doctree.traverse(addnodes.desc_signature):
+        sig.attributes["_toc_parts"] = ()
+        sig.attributes["_toc_name"] = ""
+
+
 def setup(app):
     # theme customizations
     app.add_css_file("css/custom.css")
+    # Priority 499 < default 500 so our handler runs before TocTreeCollector.process_doc,
+    # which builds sidebar entries from _toc_name/_toc_parts at priority 500.
+    app.connect("doctree-read", _fix_breathe_toc_entries, priority=499)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ breathe_default_project = "HubbleNetworkSDK"
 primary_domain = "c"
 
 # Tell sphinx what the pygments highlight language should be.
-pygments_sytle = "sphinx"
+pygments_style = "sphinx"
 highlight_language = "none"
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,10 @@ primary_domain = "c"
 pygments_style = "sphinx"
 highlight_language = "none"
 
+# Keep domain objects (C function/struct signatures documented by breathe) out
+# of the sidebar navigation TOC. They are still rendered in the page body.
+toc_object_entries = False
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -4,7 +4,7 @@ Configuration Options
 #####################
 
 The configuration options below are derived from the Zephyr Kconfig definitions
-but represent the full set of tunable parameters for the Hubble Network SDK.
+but represent the full set of tunable parameters for the Hubble Device SDK.
 The same options apply to all supported ports — Zephyr, FreeRTOS, ESP-IDF,
 bare-metal, and other RTOSes — though the mechanism for setting them varies by
 platform.

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -1,7 +1,7 @@
 .. _hubble_configuration:
 
-Configuration Reference
-#######################
+Configuration Options
+#####################
 
 The configuration options below are derived from the Zephyr Kconfig definitions
 but represent the full set of tunable parameters for the Hubble Network SDK.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,11 @@
-.. Hubble Network SDK documentation
+.. Hubble Device SDK documentation
 
 .. _hubble-home:
 
-Hubble Network SDK documentation
+Hubble Device SDK documentation
 ================================
 
-**Welcome to the Hubble Network SDK documentation!**
+**Welcome to the Hubble Device SDK documentation!**
 
 This guide will walk you through everything you need to know to integrate the
 Hubble APIs with your application or service and begin leveraging the Hubble
@@ -13,7 +13,7 @@ Network. Designed for developers who want a straightforward and reliable way to
 harness Hubble’s powerful capabilities, this SDK provides a suite of tools and
 libraries that make it easy to interact with all of Hubble’s services.
 
-Using Hubble Network SDK
+Using Hubble Device SDK
 ************************
 
 
@@ -46,7 +46,7 @@ Additional Resources
        <li class="grid-item">
 	   <a href="introduction/index.html">
                <span class="grid-icon fa fa-info"></span>
-	       <h2>About Hubble Network SDK</h2>
+	       <h2>About Hubble Device SDK</h2>
 	   </a>
 	   <p>Overview, features &amp; where to start</p>
        </li>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,9 +67,9 @@ Additional Resources
        <li class="grid-item">
 	   <a href="ble/index.html">
                <span class="grid-icon fa fa-bluetooth-b"></span>
-	       <h2>BLE Network</h2>
+	       <h2>Terrestrial Network</h2>
 	   </a>
-	   <p>BLE Network, build &amp; run a sample application</p>
+	   <p>Terrestrial Network, build &amp; run a sample application</p>
        </li>
        <li class="grid-item">
 	   <a href="satellite/index.html">
@@ -89,7 +89,7 @@ Additional Resources
    quickstart/index
    integration_guides/index
    best-practices/index
-   ble/index
+   terrestrial/index
    satellite/index
    security/index
    releases/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,4 +92,5 @@ Additional Resources
    ble/index
    satellite/index
    security/index
+   best-practices/index
    releases/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,9 +88,16 @@ Additional Resources
    architecture/index
    quickstart/index
    integration_guides/index
-   configuration/index
+   best-practices/index
    ble/index
    satellite/index
    security/index
-   best-practices/index
    releases/index
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Reference
+
+   configuration/index
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,5 +99,6 @@ Additional Resources
    :hidden:
    :caption: Reference
 
+   api/index
    configuration/index
 

--- a/docs/integration_guides/ncs/index.rst
+++ b/docs/integration_guides/ncs/index.rst
@@ -20,7 +20,7 @@ By the end of this guide you will know how to:
 Supported NCS Version and Boards
 *********************************
 
-The Hubble Network SDK currently supports **NCS v3.4.0**. If you require
+The Hubble Device SDK currently supports **NCS v3.4.0**. If you require
 support for a different version, `contact us <mailto:support@hubble.com>`_.
 
 Nordic nRF52, nRF53, and nRF54 Series SoCs are supported. The SDK includes
@@ -91,7 +91,7 @@ all required dependencies before proceeding.
 Add Hubble Network to an Existing NCS Project
 =============================================
 
-If you already have an NCS workspace, add the Hubble Network SDK as a West
+If you already have an NCS workspace, add the Hubble Device SDK as a West
 module by including the following in your project's sub-manifest or
 ``west.yml``:
 
@@ -409,8 +409,8 @@ See :ref:`hubble_satellite_orbital_params` for details on the generated format a
 how to register the array with the SDK.
 
 
-Initializing the Hubble SDK
-****************************
+Initializing the Hubble Device SDK
+**********************************
 
 Once time, location, and orbital parameters are available, initialize the SDK
 before calling any other Hubble API:
@@ -423,7 +423,7 @@ before calling any other Hubble API:
     */
    err = hubble_init(unix_time_ms, master_key);
    if (err != 0) {
-       LOG_ERR("Failed to initialize Hubble SDK (err %d)", err);
+       LOG_ERR("Failed to initialize Hubble Device SDK (err %d)", err);
        return err;
    }
 
@@ -565,7 +565,7 @@ the Multiprotocol Service Layer (MPSL) for BLE and satellite radio coexistence:
 Verifying the Application
 **************************
 
-Enable the Hubble SDK logging by adding the following to ``prj.conf``:
+Enable the Hubble Device SDK logging by adding the following to ``prj.conf``:
 
 .. code-block:: kconfig
 
@@ -582,7 +582,7 @@ After a successful :c:func:`hubble_init` call, the SDK logs:
 
 .. code-block:: none
 
-   <inf> hubblenetwork: Hubble Network SDK initialized
+   <inf> hubblenetwork: Hubble Device SDK initialized
 
 At debug level, once pass prediction runs and a transmission is scheduled, you
 will see the retry count computed from your TDR setting and the time elapsed

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -3,7 +3,7 @@
 Introduction
 ############
 
-The Hubble Network SDK is designed with flexibility and scalability in mind.
+The Hubble Device SDK is designed with flexibility and scalability in mind.
 At its core, the SDK provides two primary functionalities—Satellite
 Communication and BLE Network Communication—both built around a modular
 architecture. This approach enables straightforward extensions or adaptations

--- a/docs/quickstart/esp-idf/index.rst
+++ b/docs/quickstart/esp-idf/index.rst
@@ -3,7 +3,7 @@
 ESP-IDF Quick Start
 ===================
 
-This guide explains how to integrate the Hubble Network SDK into an
+This guide explains how to integrate the Hubble Device SDK into an
 `ESP-IDF <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html>`_
 project. The SDK ships as an ESP-IDF component that can be pulled into any
 ESP-IDF application via ``EXTRA_COMPONENT_DIRS``.
@@ -17,13 +17,13 @@ Prerequisites
 - A supported ESP32 target. The BLE Network module works on any ESP32 chip
   with a Bluetooth® Low Energy controller supported by ESP-IDF. The Satellite
   Network module currently targets the **ESP32-C6**.
-- The Hubble Network SDK cloned or added to your project as a Git submodule.
+- The Hubble Device SDK cloned or added to your project as a Git submodule.
 
 
 Adding Hubble Network to an ESP-IDF Project
 *******************************************
 
-#. Add the Hubble Network SDK to your application, for example as a submodule:
+#. Add the Hubble Device SDK to your application, for example as a submodule:
 
    .. code-block:: bash
 

--- a/docs/quickstart/freertos/index.rst
+++ b/docs/quickstart/freertos/index.rst
@@ -24,7 +24,7 @@ Adding Hubble Network to FreeRTOS
 
   .. code-block:: bash
 
-     git submodule add https://github.com/HubbleNetwork/hubble-device-sdk .
+     git submodule add https://github.com/HubbleNetwork/hubble-device-sdk
 
 
 * Provide a configuration header
@@ -95,4 +95,4 @@ Build the application
 
 .. code-block:: bash
 
-   make -C /path/to/your/application/Makefile
+   make -C /path/to/your/application

--- a/docs/quickstart/freertos/index.rst
+++ b/docs/quickstart/freertos/index.rst
@@ -4,7 +4,7 @@ FreeRTOS Quick Start
 ======================
 
 This guide provides a quick overview of how to integrate the
-Hubble Network SDK with FreeRTOS. Due to differences between various
+Hubble Device SDK with FreeRTOS. Due to differences between various
 FreeRTOS vendors, the SDK provides mechanisms to integrate it into the
 application build system. However, this integration requires some work
 from the user to adapt it to their specific environment.
@@ -20,7 +20,7 @@ Prerequisites
 Adding Hubble Network to FreeRTOS
 *********************************
 
-* Include Hubble Network SDK in your application
+* Include Hubble Device SDK in your application
 
   .. code-block:: bash
 
@@ -74,7 +74,7 @@ Example of including the Makefile fragment:
 
 .. code-block:: Makefile
 
-   # Hubble Network SDK
+   # Hubble Device SDK
 
    HUBBLENETWORK_SDK_CONFIG = $(MY_APP_DIR)/hubble_config.h
    include path/to/hubblenetwork-sdk/port/freertos/hubblenetwork-sdk.mk
@@ -86,7 +86,7 @@ Example of including the Makefile fragment:
 
    $(foreach source_file,$(HUBBLENETWORK_SDK_SOURCES),$(eval $(call HUBBLE_RULE,$(source_file))))
 
-   # Hubble Network SDK END
+   # Hubble Device SDK END
 
 
 Build the application

--- a/docs/quickstart/ti/index.rst
+++ b/docs/quickstart/ti/index.rst
@@ -186,7 +186,7 @@ SysConfig product directly from the IDE:
 4. Click **Apply and Close**. CCS will pass this flag to the SysConfig CLI
    during the build, making the ``/Hubble`` module available in your
    ``.syscfg`` script just as described in the section above. If Satellite Network
-   is enabled the additional step must be added to you ``.syscfg`` script:
+   is enabled the additional step must be added to your ``.syscfg`` script:
 
    .. code-block:: none
 

--- a/docs/quickstart/ti/index.rst
+++ b/docs/quickstart/ti/index.rst
@@ -3,17 +3,17 @@
 TI SDK Quick Start (SysConfig)
 ==============================
 
-This guide explains how to integrate the Hubble Network SDK into a
+This guide explains how to integrate the Hubble Device SDK into a
 `SimpleLink Low Power F3 SDK <https://www.ti.com/tool/SIMPLELINK-LOWPOWER-F3-SDK>`_
 project using `SysConfig <https://www.ti.com/tool/SYSCONFIG>`_. SysConfig
 generates driver and peripheral initialization code from a ``.syscfg`` script,
-and the Hubble Network SDK provides its own SysConfig product so its module
+and the Hubble Device SDK provides its own SysConfig product so its module
 can be configured alongside the TI SDK drivers in the same script.
 
 .. note::
 
    SysConfig is the recommended integration path for TI SDK projects. If you
-   prefer to manage Hubble Network SDK build manually or are working in an
+   prefer to manage Hubble Device SDK build manually or are working in an
    environment without SysConfig, follow the generic
    :ref:`freertos_quick_start` instead — it describes how to include the SDK
    sources and flags directly via the provided Makefile fragment.
@@ -24,7 +24,7 @@ Prerequisites
 - `SimpleLink Low Power F3 SDK <https://www.ti.com/tool/SIMPLELINK-LOWPOWER-F3-SDK>`_ installed.
 - `TI ARM LLVM Compiler <https://www.ti.com/tool/CCSTUDIO>`_ installed.
 - SysConfig CLI tool (``sysconfig_cli.sh`` / ``sysconfig_cli.bat``) available.
-- The Hubble Network SDK cloned or added as a submodule.
+- The Hubble Device SDK cloned or added as a submodule.
 
 Set the following environment variables before building:
 
@@ -36,10 +36,10 @@ Set the following environment variables before building:
    export HUBBLE_NETWORK_SDK=/path/to/hubble-device-sdk
 
 
-Adding the Hubble Network SDK SysConfig Product
+Adding the Hubble Device SDK SysConfig Product
 ***********************************************
 
-The Hubble Network SDK ships a SysConfig product descriptor at
+The Hubble Device SDK ships a SysConfig product descriptor at
 ``.metadata/product.json``. Pass it to the SysConfig CLI alongside the TI SDK
 product so both products are available in the same ``.syscfg`` script:
 
@@ -71,7 +71,7 @@ Load the Hubble module in your ``.syscfg`` script with:
 
    var hubble = scripting.addModule("/Hubble");
 
-This is all that is required. The module registers the Hubble Network SDK
+This is all that is required. The module registers the Hubble Device SDK
 sources and include paths with the SysConfig framework so the generated
 ``.opt`` files carry the right compiler flags.
 
@@ -88,7 +88,7 @@ A minimal ``.syscfg`` script for a BLE application on CC23xx looks like:
    var RCL   = scripting.addModule("/ti/drivers/RCL");
    var Power = scripting.addModule("/ti/drivers/Power");
 
-   /* Hubble Network SDK */
+   /* Hubble Device SDK */
    var hubble = scripting.addModule("/Hubble");
 
    /* BLE stack and FreeRTOS */
@@ -168,7 +168,7 @@ Using Code Composer Studio (CCS)
 *********************************
 
 If you are using `Code Composer Studio <https://www.ti.com/tool/CCSTUDIO>`_
-and prefer not to write a Makefile manually, you can add the Hubble Network SDK
+and prefer not to write a Makefile manually, you can add the Hubble Device SDK
 SysConfig product directly from the IDE:
 
 1. Right-click the project folder in the **Project Explorer** and select
@@ -181,7 +181,7 @@ SysConfig product directly from the IDE:
       -s "/path/to/hubble-device-sdk/.metadata/product.json"
 
    Replace ``/path/to/hubble-device-sdk`` with the actual path to your Hubble
-   Network SDK checkout.
+   Device SDK checkout.
 
 4. Click **Apply and Close**. CCS will pass this flag to the SysConfig CLI
    during the build, making the ``/Hubble`` module available in your

--- a/docs/quickstart/zephyr/index.rst
+++ b/docs/quickstart/zephyr/index.rst
@@ -48,7 +48,7 @@ the prebuilt radio support libraries declared as Zephyr module blobs:
 
    west blobs fetch hubblenetwork-sdk
 
-Run this command from a Zephyr west workspace that includes the Hubble Network
+Run this command from a Zephyr west workspace that includes the Hubble Device
 SDK module. The downloaded blobs are placed under the module's
 ``zephyr/blobs`` directory and are linked automatically when
 ``CONFIG_HUBBLE_SAT_NETWORK`` is enabled for supported Nordic boards.
@@ -77,7 +77,7 @@ Install West and all required `Zephyr dependencies
 <https://docs.zephyrproject.org/4.4.0/develop/getting_started/index
 .html#install-dependencies>`_ as described in the `Zephyr documentation <https://docs.zephyrproject
 .org/4.4.0/develop/toolchains/zephyr_sdk.html#zephyr-sdk-installation>`_. The
-following steps outline the process of creating a Zephyr workspace that uses the Hubble Network SDK as the manifest repository:
+following steps outline the process of creating a Zephyr workspace that uses the Hubble Device SDK as the manifest repository:
 
 
 .. _Python virtual environment: https://docs.python.org/3/library/venv.html

--- a/docs/releases/1.0.rst
+++ b/docs/releases/1.0.rst
@@ -5,7 +5,7 @@ Release 1.0.0
 
 **Release Date**: January 6, 2026
 
-This is the first stable release of the Hubble Network Device SDK. This release
+This is the first stable release of the Hubble Device SDK. This release
 provides a production-ready SDK for connecting Bluetooth® Low Energy
 (BLE) embedded devices to the Hubble **Terrestrial Network**.
 
@@ -17,7 +17,7 @@ provides a production-ready SDK for connecting Bluetooth® Low Energy
 Overview
 ********
 
-Release 1.0.0 represents a significant milestone for the Hubble Network Device SDK,
+Release 1.0.0 represents a significant milestone for the Hubble Device SDK,
 delivering a stable, well-tested foundation for building applications that leverage
 Hubble Terrestrial Network (BLE) infrastructure. This release includes
 comprehensive platform support, robust security features, and extensive
@@ -35,7 +35,7 @@ participate in secure BLE communication:
 - **Secure Communication**: Encryption used for all network communications
 - **Advertisement Generation**: API for generating Bluetooth advertisement packets
   compatible with Hubble Network infrastructure
-- **Bluetooth Qualification**: The Hubble Network Device SDK has completed
+- **Bluetooth Qualification**: The Hubble Device SDK has completed
   the Bluetooth Qualification Process (Design Number: Q369913)
 
 Platform Support

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -3,7 +3,7 @@
 Release Notes and Lifecycle
 ############################
 
-This document describes the Hubble Network SDK release process, versioning
+This document describes the Hubble Device SDK release process, versioning
 strategy, and support policies. Understanding these policies helps developers
 plan their integration efforts and make informed decisions about when to upgrade
 to new releases.
@@ -11,7 +11,7 @@ to new releases.
 Overview
 ********
 
-The Hubble Network SDK follows a structured release lifecycle designed to ensure
+The Hubble Device SDK follows a structured release lifecycle designed to ensure
 stability, reliability, and backward compatibility. Releases progress through
 distinct phases from initial development through release candidates to stable
 production releases. The SDK adheres to `Semantic Versioning`_ principles to
@@ -22,7 +22,7 @@ clearly communicate the nature and impact of each release.
 Release Lifecycle
 *****************
 
-The Hubble Network SDK release process consists of three primary phases:
+The Hubble Device SDK release process consists of three primary phases:
 
 Development Phase
 =================
@@ -99,7 +99,7 @@ dimensions:
 Release Model
 *************
 
-The Hubble Network SDK uses `Semantic Versioning`_ with the format
+The Hubble Device SDK uses `Semantic Versioning`_ with the format
 ``MAJOR.MINOR.PATCH`` (e.g., ``1.4.2``).
 
 Version Components
@@ -153,7 +153,7 @@ The following guidelines determine version increments:
 Release Types
 *************
 
-The Hubble Network SDK maintains two types of releases:
+The Hubble Device SDK maintains two types of releases:
 
 Stable Releases
 ===============
@@ -188,7 +188,7 @@ LTS releases are explicitly marked in release announcements and documentation.
 Support Policy
 **************
 
-The Hubble Network SDK maintains different support levels depending on release
+The Hubble Device SDK maintains different support levels depending on release
 type:
 
 Stable  Releases
@@ -214,7 +214,7 @@ LTS releases receive:
 Release Schedule
 ****************
 
-The Hubble Network SDK follows a predictable release schedule:
+The Hubble Device SDK follows a predictable release schedule:
 
 Regular Releases
 ================
@@ -235,10 +235,10 @@ All releases are announced through:
 - Release notes with detailed changelogs
 - Migration guides for major version upgrades
 
-For the most current release information, visit the `Hubble Network SDK GitHub
+For the most current release information, visit the `Hubble Device SDK GitHub
 repository`_.
 
-.. _Hubble Network SDK GitHub repository: https://github.com/hubblenetwork/hubble-device-sdk
+.. _Hubble Device SDK GitHub repository: https://github.com/hubblenetwork/hubble-device-sdk
 
 Migration and Upgrade Guidance
 ******************************

--- a/docs/satellite/board-support.rst
+++ b/docs/satellite/board-support.rst
@@ -3,7 +3,7 @@
 Supporting New Boards
 #####################
 
-The Hubble Network SDK separates satellite support into three layers:
+The Hubble Device SDK separates satellite support into three layers:
 
 * the common satellite module in ``src``;
 * the RTOS or framework port in ``port/<rtos>``;

--- a/docs/satellite/index.rst
+++ b/docs/satellite/index.rst
@@ -290,7 +290,7 @@ Typical workflow:
 
 1. Start BLE provisioning.
 2. Receive Unix time, device location, and satellite orbital parameters.
-3. Initialize the Hubble SDK with the provisioned Unix time and key.
+3. Initialize the Hubble Device SDK with the provisioned Unix time and key.
 4. Register orbital parameters with :c:func:`hubble_sat_satellites_set`.
 5. Compute the next pass with :c:func:`hubble_sat_next_pass_get`.
 6. Start BLE beaconing while waiting for ``pass.start``.

--- a/docs/satellite/index.rst
+++ b/docs/satellite/index.rst
@@ -551,14 +551,13 @@ Important related options include:
   size selection.
 * ``CONFIG_HUBBLE_NETWORK_CRYPTO_*`` for crypto backend selection.
 
-See :ref:`hubble_configuration` for the complete configuration reference.
+See :ref:`hubble_configuration` for the complete configuration reference. The
+full satellite API is documented in the :ref:`hubble_sat_api` reference.
 
-API Reference
+Board Support
 *************
 
 .. toctree::
    :maxdepth: 1
-   :glob:
 
-   api.rst
    board-support

--- a/docs/security/cryptography.rst
+++ b/docs/security/cryptography.rst
@@ -3,7 +3,7 @@
 Cryptographic Overview
 ######################
 
-The Hubble Network SDK protects transmitted data with the same set of
+The Hubble Device SDK protects transmitted data with the same set of
 cryptographic primitives across both the BLE (Terrestrial) Network and the
 Satellite Network, ensuring the confidentiality, integrity, and authenticity of
 every message. AES provides strong encryption, CMAC ensures data integrity and

--- a/docs/security/cryptography.rst
+++ b/docs/security/cryptography.rst
@@ -1,14 +1,15 @@
 .. _hubble_ble_security:
 
-BLE  Security Overview
+Cryptographic Overview
 ######################
 
-The cryptographic techniques used in the Hubble Bluetooth® Low Energy (BLE) Network ensure
-the confidentiality, integrity, and authenticity of the data being advertised
-over BLE. AES-256 provides strong encryption, CMAC ensures data integrity and
+The Hubble Network SDK protects transmitted data with the same set of
+cryptographic primitives across both the BLE (Terrestrial) Network and the
+Satellite Network, ensuring the confidentiality, integrity, and authenticity of
+every message. AES provides strong encryption, CMAC ensures data integrity and
 authenticity, and the KBKDF securely derives keys from a master key. The use
 of nonces and sequence numbers prevents replay attacks and ensures that each
-advertisement is unique.
+transmission is unique.
 
 Key concepts
 ************
@@ -43,7 +44,7 @@ Key concepts
 
 
 Encryption steps
-################
+****************
 
 
 An application will get the encrypted advertisement data using
@@ -58,7 +59,7 @@ following steps to prepare the advertisement data:
 
 
 Additional references
-#####################
+*********************
 
 * `FIPS 197 - Advanced Encryption Standard (AES): <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.197-upd1.pdf>`_
 

--- a/docs/security/index.rst
+++ b/docs/security/index.rst
@@ -5,7 +5,7 @@ Security
 
 .. toctree::
    :maxdepth: 1
-   :glob:
 
-   vulnerability-process.rst
-   vulnerabilities.rst
+   cryptography
+   vulnerability-process
+   vulnerabilities

--- a/docs/static/css/dark.css
+++ b/docs/static/css/dark.css
@@ -26,7 +26,7 @@
     --navbar-button-color: var(--lunar-dust);
     --navbar-button-active-color: var(--white);
 
-    --navbar-heading-color: rgba(170, 175, 253, 0.10);
+    --navbar-heading-color: rgba(170, 175, 253, 0.75);
     --navbar-scrollbar-color: rgba(170, 175, 253, 0.10);
     --navbar-scrollbar-hover-color: rgba(170, 175, 253, 0.10);
     --navbar-scrollbar-active-color: rgba(170, 175, 253, 0.10);

--- a/docs/static/css/light.css
+++ b/docs/static/css/light.css
@@ -26,7 +26,7 @@
     --navbar-button-color: var(--lunar-dust);
     --navbar-button-active-color: var(--white);
 
-    --navbar-heading-color: rgba(170, 175, 253, 0.10);
+    --navbar-heading-color: rgba(170, 175, 253, 0.75);
     --navbar-scrollbar-color: rgba(170, 175, 253, 0.10);
     --navbar-scrollbar-hover-color: rgba(170, 175, 253, 0.10);
     --navbar-scrollbar-active-color: rgba(170, 175, 253, 0.10);

--- a/docs/terrestrial/index.rst
+++ b/docs/terrestrial/index.rst
@@ -1,18 +1,28 @@
-.. _hubble_ble_introduction:
+.. _hubble_terrestrial_introduction:
 
-BLE Network Overview
-####################
+Terrestrial Network Overview
+############################
 
 
 Introduction
 ************
 
-The Hubble Bluetooth® Low Energy (BLE) Network is a framework designed to provide secure
-and efficient communication within a Bluetooth Low Energy (BLE) environment.
+The Hubble Terrestrial Network is the name Hubble uses for its network built on
+Bluetooth® Low Energy (BLE). It is a framework designed to provide secure and
+efficient communication within a Bluetooth Low Energy (BLE) environment.
 Advanced encryption techniques and Bluetooth technology protect data
-integrity and privacy across distributed systems. The Hubble BLE API, defined
+integrity and privacy across distributed systems. The Hubble Terrestrial API, definede
 in the **hubble/ble.h** header file, provides a comprehensive set of functions
 for initializing, configuring, and managing network operations.
+
+.. note::
+
+   While this network is called the *Hubble Terrestrial Network*, the SDK code
+   and APIs use the ``ble`` namespace for it. Terrestrial functions, types, and
+   configuration options carry a ``ble`` marker — for example the
+   :c:func:`hubble_ble_advertise_get` function, the ``hubble/ble.h`` header, and
+   the ``CONFIG_HUBBLE_BLE_NETWORK`` option — reflecting the Bluetooth Low
+   Energy technology the network is built on.
 
 Key Features
 ============
@@ -20,7 +30,7 @@ Key Features
 Secure Communication
 --------------------
 
-The Hubble BLE Network uses a 128 or 256-bit encryption key to safeguard all
+The Hubble Terrestrial Network uses a 128 or 256-bit encryption key to safeguard all
 transmitted data, minimizing the risk of unauthorized access and data
 breaches. See :ref:`hubble_ble_security`
 
@@ -35,7 +45,7 @@ for best practices on provisioning time and accounting for clock drift.
 Advertisement Management
 ------------------------
 
-The Hubble BLE API processes input data to generate Bluetooth advertisements.
+The Hubble Terrestrial Network API processes input data to generate Bluetooth advertisements.
 These advertisements are essential for device discovery and communication
 within the BLE network. The API returns platform-specific pointers to the
 generated advertisements, allowing for seamless integration with various
@@ -48,7 +58,7 @@ Initialization
 ==============
 
 Initialize the network with the current Unix time before calling other Hubble
-BLE API functions. The ``hubble_init`` function sets up the required
+Terrestrial API functions. The ``hubble_init`` function sets up the required
 configurations and prepares the network for operation:
 
 .. code-block:: c

--- a/include/hubble/hubble.h
+++ b/include/hubble/hubble.h
@@ -22,13 +22,13 @@ extern "C" {
 #endif
 
 /**
- * @brief Hubble Network SDK APIs
- * @defgroup hubble_api Hubble Network APIs
+ * @brief Hubble Device SDK APIs
+ * @defgroup hubble_api Hubble Device SDK APIs
  * @{
  */
 
 /**
- * @brief Initializes the Hubble SDK.
+ * @brief Initializes the Hubble Device SDK.
  *
  * Calling this function is essential before using any other SDK APIs.
  *
@@ -77,7 +77,7 @@ extern "C" {
 int hubble_init(uint64_t initial_time, const void *key);
 
 /**
- * @brief Sets the current Unix time in the Hubble SDK.
+ * @brief Sets the current Unix time in the Hubble Device SDK.
  *
  * @param unix_time The Unix Epoch time in milliseconds since the Unix epoch
  *                  (January 1, 1970).

--- a/include/hubble/port/crypto.h
+++ b/include/hubble/port/crypto.h
@@ -35,7 +35,7 @@ extern "C" {
 #define HUBBLE_KEY_SIZE_BITS (CONFIG_HUBBLE_KEY_SIZE * 8)
 
 /**
- * @brief Hubble Network SDK Crypto APIs.
+ * @brief Hubble Device SDK Crypto APIs.
  *
  * Cryptographic functions that need to be implemented by
  * a crypto provider.

--- a/samples/esp-idf/ble-beacon/README.md
+++ b/samples/esp-idf/ble-beacon/README.md
@@ -1,6 +1,6 @@
 # Hubble Network BLE ESP-IDF Beacon Sample
 
-This sample application demonstrates how to use the Hubble Network SDK to
+This sample application demonstrates how to use the Hubble Device SDK to
 create a BLE beacon that advertises its presence.
 
 ## Requirements

--- a/samples/esp-idf/sat-continuous/README.md
+++ b/samples/esp-idf/sat-continuous/README.md
@@ -1,6 +1,6 @@
 # Hubble Network Sat Continuous Sample
 
-This sample application demonstrates how to use the Hubble Network SDK to
+This sample application demonstrates how to use the Hubble Device SDK to
 continuously transmit packets to satellite.
 
 ## Requirements
@@ -20,7 +20,7 @@ This project is designed to:
 - Provide a practical starting point for developers integrating the Hubble
   Satellite Network on ESP32-C6 hardware.
 
-Once running, the device initializes the Hubble SDK and then enters a loop that
+Once running, the device initializes the Hubble Device SDK and then enters a loop that
 builds and transmits a satellite packet with normal reliability.
 
 

--- a/samples/esp-idf/sat-dtm/README.md
+++ b/samples/esp-idf/sat-dtm/README.md
@@ -6,7 +6,7 @@ This sample enables the Direct Test Mode (DTM) functions for the Hubble
 Satellite Network on ESP32-C6 hardware. It can be used for RF testing,
 certification (FCC/CE), and bring-up of new hardware.
 
-The sample initializes the Hubble SDK and starts an interactive shell over the
+The sample initializes the Hubble Device SDK and starts an interactive shell over the
 serial console.
 
 ## Requirements

--- a/samples/freertos/ti/ble-beacon/README.md
+++ b/samples/freertos/ti/ble-beacon/README.md
@@ -76,7 +76,7 @@ make
 ```
 
    Alternatively, use the SysConfig-based build (*makefile-syscfg*), which generates driver and
-   peripheral configuration via SysConfig using both the TI SDK and Hubble Network SDK products:
+   peripheral configuration via SysConfig using both the TI SDK and Hubble Device SDK products:
 
 ```bash
 make -f makefile-syscfg
@@ -108,5 +108,5 @@ Once the firmware is flashed:
 + **src/hubble_ble_adv.c**: BLE advertising implementation.
 + **src/hubble_ble_ti.c**: This is a core file to integrate with HubbleNetwork SDK. It implements the required cryptograhic API.
 + **makefile**: Build system for the project.
-+ **makefile-syscfg**: SysConfig-based build system; generates driver configuration using both the TI SDK and Hubble Network SDK SysConfig products.
-+ **ble-beacon-hubble.syscfg**: SysConfig script that configures drivers, BLE stack, FreeRTOS, and the Hubble Network SDK module.
++ **makefile-syscfg**: SysConfig-based build system; generates driver configuration using both the TI SDK and Hubble Device SDK SysConfig products.
++ **ble-beacon-hubble.syscfg**: SysConfig script that configures drivers, BLE stack, FreeRTOS, and the Hubble Device SDK module.

--- a/samples/freertos/ti/sat-dtm/sat-dtm.syscfg
+++ b/samples/freertos/ti/sat-dtm/sat-dtm.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --board "/ti/boards/LP_EM_CC2755P10" --rtos "freertos" --product "simplelink_lowpower_f3_sdk@9.20.00.81" --product "Hubble Network SDK@1.0.0"
- * @v2CliArgs --board "/ti/boards/LP_EM_CC2755P10" --rtos "freertos" --product "simplelink_lowpower_f3_sdk@9.20.00.81" --product "Hubble Network SDK@1.0.0"
+ * @cliArgs --board "/ti/boards/LP_EM_CC2755P10" --rtos "freertos" --product "simplelink_lowpower_f3_sdk@9.20.00.81" --product "Hubble Device SDK@1.0.0"
+ * @v2CliArgs --board "/ti/boards/LP_EM_CC2755P10" --rtos "freertos" --product "simplelink_lowpower_f3_sdk@9.20.00.81" --product "Hubble Device SDK@1.0.0"
  * @versions {"tool":"1.26.3+4529"}
  */
 

--- a/samples/zephyr/ble-beacon-mfg-data/src/main.c
+++ b/samples/zephyr/ble-beacon-mfg-data/src/main.c
@@ -118,7 +118,7 @@ int main(void)
 	}
 
 	/*
-	 * Initialize the Hubble SDK with the provisioned master key. This sample
+	 * Initialize the Hubble Device SDK with the provisioned master key. This sample
 	 * uses the device uptime counter source
 	 * (CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME), so no UTC time is needed:
 	 * we pass 0 as the initial EID counter value and it advances with uptime.

--- a/samples/zephyr/ble-beacon/README.md
+++ b/samples/zephyr/ble-beacon/README.md
@@ -1,6 +1,6 @@
 # Hubble Network BLE Beacon Sample
 
-This sample application demonstrates how to use the Hubble Network SDK to
+This sample application demonstrates how to use the Hubble Device SDK to
 create a BLE beacon that advertises its presence.
 
 ## Requirements

--- a/samples/zephyr/ble-network/README.md
+++ b/samples/zephyr/ble-network/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-This sample application demonstrates how to use the Hubble Network SDK on a
+This sample application demonstrates how to use the Hubble Device SDK on a
 Zephyr-based device to broadcast data over Bluetooth Low Energy (BLE).
 
-The application initializes the Hubble SDK, sets an encryption key and a Unix
+The application initializes the Hubble Device SDK, sets an encryption key and a Unix
 timestamp, and then advertises user-provided data within a BLE packet. It
 provides a shell interface over the serial port to input the necessary
 configuration and data.
@@ -102,7 +102,7 @@ In the sample's shell, run the `unix_time` command with the timestamp:
 uart:~$ time 1752865580290
 ```
 
-Once the Unix time is set, the application will initialize the Hubble SDK and
+Once the Unix time is set, the application will initialize the Hubble Device SDK and
 the Bluetooth subsystem.
 
 ### Step 3: Advertise Data
@@ -113,7 +113,7 @@ Now you can provide the data you want to broadcast using the `data` command.
 uart:~$ data "Hello Hubble"
 ```
 
-The application will take this string, process it with the Hubble SDK, and
+The application will take this string, process it with the Hubble Device SDK, and
 place the resulting data in the service data field of its BLE advertisement
 packet.
 

--- a/src/hubble.c
+++ b/src/hubble.c
@@ -96,7 +96,7 @@ int hubble_init(uint64_t initial_time, const void *key)
 	}
 #endif /* CONFIG_HUBBLE_SAT_NETWORK */
 
-	HUBBLE_LOG_INFO("Hubble Network SDK initialized\n");
+	HUBBLE_LOG_INFO("Hubble Device SDK initialized\n");
 
 	return 0;
 }

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -47,7 +47,7 @@ def get_pkt_from_be_with_timestamp(org, device, timestamp):
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 def cli() -> None:
-    """Hubble SDK CLI."""
+    """Hubble Device SDK CLI."""
     # top-level group; subcommands are added below
 
 


### PR DESCRIPTION
- Consolidate the name of the SDK as "Hubble Device SDK"
- Put all APIs under a new section
- Rename the BLE Network to Terrestrial Network (no code changes !)
- Scattered fixes, see individual commits for more information.