### PR TITLE
api: hubble_init: separate unix_time and initial_counter arguments

### DIFF
--- a/docs/integration_guides/ncs/index.rst
+++ b/docs/integration_guides/ncs/index.rst
@@ -421,7 +421,7 @@ before calling any other Hubble API:
     * At this point unix_time_ms, device_pos, and orb_params are assumed to be
     * valid. Either baked into firmware or received via BLE provisioning.
     */
-   err = hubble_init(unix_time_ms, master_key);
+   err = hubble_init(unix_time_ms, 0, master_key);
    if (err != 0) {
        LOG_ERR("Failed to initialize Hubble Device SDK (err %d)", err);
        return err;

--- a/docs/quickstart/bare-metal/index.rst
+++ b/docs/quickstart/bare-metal/index.rst
@@ -76,12 +76,16 @@ The counter advances once per :ref:`EID rotation period
 <bare_metal_eid_rotation_period>` (daily by default) and wraps at the EID pool
 size of ``128``.
 
-:c:func:`hubble_init` takes the **initial counter value** rather than a
-timestamp:
+:c:func:`hubble_init` takes the counter as its **second** argument,
+``initial_counter``, and the Unix time as its **first** argument,
+``unix_time``:
 
-- Pass ``0`` to start at counter epoch 0 (valid).
-- Pass a previously saved counter to resume from a known state after a reboot,
-  preserving continuity across power cycles.
+- Pass ``0`` as ``initial_counter`` to start at counter epoch 0 (valid).
+- Pass a previously saved counter as ``initial_counter`` to resume from a
+  known state after a reboot, preserving continuity across power cycles.
+- ``unix_time`` is optional in this mode: pass ``0`` if no clock is
+  available, or a non-zero Unix time to also seed :c:func:`hubble_time_get`
+  (useful for timestamps even without driving the EID counter).
 
 Use :c:func:`hubble_counter_get` to read the current counter value so your
 application can persist it to non-volatile storage and reload it on the next
@@ -89,20 +93,20 @@ boot. Its signature is ``int hubble_counter_get(uint32_t *counter)``: it returns
 a status code (``0`` on success) and writes the counter value through the
 pointer. In device uptime mode the value it returns is the wrapped pool counter
 in the range ``0`` to ``127``. That is exactly the form :c:func:`hubble_init`
-expects as its initial counter, so saving it and passing it back on the next
-boot restores counter continuity across the reboot.
+expects as its ``initial_counter``, so saving it and passing it back on the
+next boot restores counter continuity across the reboot.
 
 .. code-block:: c
 
-   /* Device uptime mode — start at counter epoch 0 */
-   int ret = hubble_init(0, master_key);
+   /* Device uptime mode — start at counter epoch 0, no time available */
+   int ret = hubble_init(0, 0, master_key);
 
    /* Device uptime mode — resume from a saved counter after reboot.
     * hubble_counter_get() writes a uint32_t (the wrapped 0..127 pool
     * value), so store and reload the counter as uint32_t. hubble_init()
-    * accepts it as the uint64_t initial counter. */
+    * accepts it directly as the uint32_t initial_counter. */
    uint32_t saved_counter = your_nvs_read_u32("hubble_counter");
-   int ret = hubble_init(saved_counter, master_key);
+   int ret = hubble_init(0, saved_counter, master_key);
 
 .. tip::
 
@@ -126,7 +130,7 @@ milliseconds since the Unix epoch**:
 
    /* Unix time mode — provide current Unix time in milliseconds */
    uint64_t unix_time_ms = 1705881600000;
-   int ret = hubble_init(unix_time_ms, master_key);
+   int ret = hubble_init(unix_time_ms, 0, master_key);
 
 
 Source Files
@@ -587,12 +591,14 @@ Validation
 Test your port by:
 
 #. Verifying ``hubble_uptime_get()`` returns monotonically increasing values.
-#. Calling :c:func:`hubble_init` with your key and the appropriate initial value
-   for your counter source:
+#. Calling :c:func:`hubble_init` with your key, a Unix time, and an initial
+   counter value appropriate for your counter source:
 
-   - **Device uptime mode:** an initial counter value (``0`` to start at epoch
-     0, or a saved counter to resume).
-   - **Unix time mode:** a known, non-zero Unix timestamp in milliseconds.
+   - **Device uptime mode:** pass the initial counter (``0`` to start at epoch
+     0, or a saved counter to resume); ``unix_time`` may be ``0`` when no clock
+     is available.
+   - **Unix time mode:** pass a known, non-zero Unix timestamp in milliseconds;
+     ``initial_counter`` is ignored.
 
 #. Generating advertisements with :c:func:`hubble_ble_advertise_get` and
    verifying output length.

--- a/docs/satellite/index.rst
+++ b/docs/satellite/index.rst
@@ -240,9 +240,10 @@ Use continuous transmission when the device is constantly powered, when power is
 not the primary constraint, or when validating radio integration. The sample
 applications under ``samples/*/sat-continuous`` follow this pattern.
 
-The example below initializes the SDK with ``hubble_init(0, master_key)``. This
-requires ``CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME`` so the time counter is
-derived from device uptime.
+The example below initializes the SDK with ``hubble_init(0, 0, master_key)``.
+This requires ``CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME`` so the time counter
+is derived from device uptime; the first argument is the (here unknown) Unix
+time and the second is the initial counter value.
 
 Typical workflow:
 
@@ -255,7 +256,7 @@ Typical workflow:
 
 .. code-block:: c
 
-   err = hubble_init(0, master_key);
+   err = hubble_init(0, 0, master_key);
    if (err != 0) {
            return err;
    }
@@ -300,7 +301,7 @@ Typical workflow:
 
 .. code-block:: c
 
-   err = hubble_init(unix_time_ms, master_key);
+   err = hubble_init(unix_time_ms, 0, master_key);
    if (err != 0) {
            return err;
    }

--- a/docs/terrestrial/index.rst
+++ b/docs/terrestrial/index.rst
@@ -63,7 +63,7 @@ configurations and prepares the network for operation:
 
 .. code-block:: c
 
-    int hubble_init(uint64_t initial_time, const void *key);
+    int hubble_init(uint64_t unix_time, uint32_t initial_counter, const void *key);
 
 Time Management
 ===============

--- a/include/hubble/hubble.h
+++ b/include/hubble/hubble.h
@@ -32,36 +32,42 @@ extern "C" {
  *
  * Calling this function is essential before using any other SDK APIs.
  *
- * The interpretation of the `initial_time` parameter depends on the configured
- * counter source:
+ * `unix_time` and `initial_counter` are independent parameters; how each is
+ * used depends on the configured counter source:
  *
  * **Unix time mode (CONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME):**
- *   - `initial_time` is the time in milliseconds since Unix epoch
- *   - Value of 0 is invalid and will return an error
- *   - Time can be updated later via hubble_time_set()
+ *   - `unix_time` drives the EID counter and must be non-zero for
+ *     hubble_counter_get() to succeed.
+ *   - `initial_counter` is a no-op in this mode, reserved for future use /
+ *     device uptime mode only.
  *
  * **Device uptime mode (CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME):**
- *   - `initial_time` is the initial counter value
- *   - Value of 0 starts the counter at epoch 0 (valid)
- *   - The counter increments based on uptime from this initial value
- *   - Useful for resuming from a known state after reboot
+ *   - `initial_counter` seeds the EID counter. A value of 0 starts the
+ *     counter at epoch 0 (valid); a saved counter resumes from a known state
+ *     after reboot.
+ *   - `unix_time` is optional here: when non-zero it seeds the SDK clock so
+ *     hubble_time_get(), satellite pass prediction, and BLE advertisement
+ *     timestamps work.
  *
  * @code
  * // Unix time mode example
  * uint64_t unix_time_ms = 1705881600000; // Current Unix Epoch time
- * int ret = hubble_init(unix_time_ms, master_key);
+ * int ret = hubble_init(unix_time_ms, 0, master_key);
  *
- * // Device uptime mode example (start at 0)
- * int ret = hubble_init(0, master_key);
+ * // Device uptime mode example (start at 0, no time available)
+ * int ret = hubble_init(0, 0, master_key);
  *
- * // Device uptime mode example (resume from saved counter)
- * uint64_t saved_counter = load_from_flash();
- * int ret = hubble_init(saved_counter, master_key);
+ * // Device uptime mode example (resume from saved counter, time known)
+ * uint32_t saved_counter = load_from_flash();
+ * int ret = hubble_init(unix_time_ms, saved_counter, master_key);
  * @endcode
  *
- * @param initial_time For Unix time mode: Unix time in milliseconds since
- *                     epoch. For device uptime mode: Initial counter value
- *                     (0 = start at 0).
+ * @param unix_time Unix time in milliseconds since epoch. Applied via
+ *                  hubble_time_set() whenever non-zero, in both counter-source
+ *                  modes. 0 means "time unknown" and is skipped without error.
+ * @param initial_counter Initial EID counter value (0 = start at epoch 0).
+ *                        Only meaningful in device uptime mode; ignored
+ *                        (reserved for future use) in Unix time mode.
  * @param key An opaque pointer to the master key buffer. The SDK
  *            stores this pointer directly and does not copy the key
  *            data. The caller must ensure the buffer remains valid
@@ -74,7 +80,7 @@ extern "C" {
  *          - 0 on success.
  *          - Non-zero on failure.
  */
-int hubble_init(uint64_t initial_time, const void *key);
+int hubble_init(uint64_t unix_time, uint32_t initial_counter, const void *key);
 
 /**
  * @brief Sets the current Unix time in the Hubble Device SDK.

--- a/samples/esp-idf/ble-beacon/main/main.c
+++ b/samples/esp-idf/ble-beacon/main/main.c
@@ -100,7 +100,7 @@ void app_main(void)
 	esp_err_t ret;
 	esp_timer_handle_t adv_timer;
 
-	ret = hubble_init(unix_time, master_key);
+	ret = hubble_init(unix_time, 0, master_key);
 	if (ret != 0) {
 		ESP_LOGE(DEMO_TAG, "Failed to initialize Hubble BLE Network");
 		return;

--- a/samples/esp-idf/sat-continuous/main/main.c
+++ b/samples/esp-idf/sat-continuous/main/main.c
@@ -70,7 +70,7 @@ void app_main(void)
 	}
 #endif
 
-	err = hubble_init(_unix_time_ms, _hubble_key);
+	err = hubble_init(_unix_time_ms, 0, _hubble_key);
 	if (err != 0) {
 		ESP_LOGE(APP_TAG,
 			 "Failed to initialize Hubble Sat Network, error: %d",

--- a/samples/esp-idf/sat-dtm/main/main.c
+++ b/samples/esp-idf/sat-dtm/main/main.c
@@ -469,7 +469,7 @@ void app_main(void)
 	 * We don't need real key and time since we don't have any
 	 * requirement for the payload content.
 	 */
-	if (hubble_init(0U, _dummy_key) != 0) {
+	if (hubble_init(0U, 0U, _dummy_key) != 0) {
 		ESP_LOGE(APP_TAG, "Failed to initialize Hubble Network");
 		return;
 	}

--- a/samples/esp-idf/sat-dual-stack/main/main.c
+++ b/samples/esp-idf/sat-dual-stack/main/main.c
@@ -126,7 +126,7 @@ void app_main(void)
 	xSemaphoreTake(sync_sem, portMAX_DELAY);
 
 	/* Init Hubble */
-	ret = hubble_init(unix_time_ms, _hubble_key);
+	ret = hubble_init(unix_time_ms, 0, _hubble_key);
 	if (ret != 0) {
 		ESP_LOGE(APP_TAG,
 			 "Failed to initialize Hubble Network, ret: %d", ret);

--- a/samples/freertos/ti/ble-beacon/src/main.c
+++ b/samples/freertos/ti/ble-beacon/src/main.c
@@ -62,7 +62,7 @@ void App_StackInitDoneHandler(gapDeviceInitDoneEvent_t *deviceInitDoneData)
 
 	(void)deviceInitDoneData;
 
-	err = hubble_init(unix_time, master_key);
+	err = hubble_init(unix_time, 0, master_key);
 	if (err != 0) {
 		Log_printf(LogModule_Beacon, Log_ERROR,
 			   "Failed to initialize Hubble, err: %d", err);

--- a/samples/freertos/ti/sat-continuous/src/main.c
+++ b/samples/freertos/ti/sat-continuous/src/main.c
@@ -41,7 +41,7 @@ void *mainThread(void *arg0)
 	struct hubble_sat_packet packet;
 	int ret;
 
-	ret = hubble_init(unix_time, master_key);
+	ret = hubble_init(unix_time, 0, master_key);
 	if (ret != 0) {
 		/* TODO: Call Error Handler */
 		return NULL;

--- a/samples/freertos/ti/sat-dtm/src/main.c
+++ b/samples/freertos/ti/sat-dtm/src/main.c
@@ -36,7 +36,7 @@ int main(void)
 	 * We don't need a real key since we don't have any requirement
 	 * for the payload contents.
 	 */
-	retc = hubble_init(0U, _hubble_key);
+	retc = hubble_init(0U, 0U, _hubble_key);
 	if (retc != 0) {
 		while (1) {
 			/* TODO: add error handling */

--- a/samples/freertos/ti/sat-dual-stack/src/main.c
+++ b/samples/freertos/ti/sat-dual-stack/src/main.c
@@ -112,7 +112,7 @@ void *main_thread_entry(void *arg0)
 		return NULL;
 	}
 
-	ret = hubble_init(unix_time_ms, master_key);
+	ret = hubble_init(unix_time_ms, 0, master_key);
 	if (ret != 0) {
 		Log_printf(Log_Dual_Stack, Log_ERROR,
 			   "Failed to init Hubble SDK");

--- a/samples/zephyr/ble-beacon-mfg-data/src/main.c
+++ b/samples/zephyr/ble-beacon-mfg-data/src/main.c
@@ -123,7 +123,7 @@ int main(void)
 	 * (CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME), so no UTC time is needed:
 	 * we pass 0 as the initial EID counter value and it advances with uptime.
 	 */
-	err = hubble_init(0, master_key);
+	err = hubble_init(0, 0, master_key);
 	if (err != 0) {
 		LOG_ERR("Failed to initialize Hubble BLE Network (err %d)", err);
 		goto end;

--- a/samples/zephyr/ble-beacon/src/main.c
+++ b/samples/zephyr/ble-beacon/src/main.c
@@ -194,7 +194,7 @@ int main(void)
 	}
 #endif /* CONFIG_HUBBLE_BEACON_SAMPLE_USE_CTS */
 
-	err = hubble_init(unix_time, master_key);
+	err = hubble_init(unix_time, 0, master_key);
 	if (err != 0) {
 		LOG_ERR("Failed to initialize Hubble BLE Network");
 		goto end;

--- a/samples/zephyr/ble-network/src/main.c
+++ b/samples/zephyr/ble-network/src/main.c
@@ -183,7 +183,7 @@ int main(void)
 
 	LOG_DBG("Key and Unix Epoch time set");
 
-	err = hubble_init(unix_time, NULL);
+	err = hubble_init(unix_time, 0, NULL);
 	if (err != 0) {
 		LOG_ERR("Failed to initialize Hubble BLE Network");
 		return err;

--- a/samples/zephyr/sat-continuous/src/main.c
+++ b/samples/zephyr/sat-continuous/src/main.c
@@ -97,7 +97,7 @@ int main(void)
 	 * (CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME), so no UTC time is needed:
 	 * we pass 0 as the initial EID counter value and it advances with uptime.
 	 */
-	err = hubble_init(0, master_key);
+	err = hubble_init(0, 0, master_key);
 	if (err != 0) {
 		LOG_ERR("Failed to initialize Hubble Sat Network");
 		goto end;

--- a/samples/zephyr/sat-dtm/src/main.c
+++ b/samples/zephyr/sat-dtm/src/main.c
@@ -417,7 +417,7 @@ static int _hubble_init(void)
 	static uint8_t _hubble_key[CONFIG_HUBBLE_KEY_SIZE];
 
 	/* Same for time. It is not needed. */
-	return hubble_init(0U, _hubble_key);
+	return hubble_init(0U, 0U, _hubble_key);
 }
 
 SYS_INIT(_hubble_init, APPLICATION, 0);

--- a/samples/zephyr/sat-dual-stack/src/main.c
+++ b/samples/zephyr/sat-dual-stack/src/main.c
@@ -104,7 +104,7 @@ int main(void)
 	LOG_INF("Waiting for provisioning over BLE...");
 	k_sem_take(&sync_sem, K_FOREVER);
 
-	err = hubble_init(unix_time_ms, _hubble_key);
+	err = hubble_init(unix_time_ms, 0, _hubble_key);
 	if (err != 0) {
 		LOG_ERR("Failed to initialize Hubble Network (err %d)", err);
 		return err;

--- a/src/hubble.c
+++ b/src/hubble.c
@@ -51,7 +51,7 @@ uint64_t hubble_time_get(void)
 	return (unix_time_synced == 0) ? 0 : unix_time_base + hubble_uptime_get();
 }
 
-int hubble_init(uint64_t initial_time, const void *key)
+int hubble_init(uint64_t unix_time, uint32_t initial_counter, const void *key)
 {
 	int ret = hubble_lock_init();
 
@@ -67,17 +67,28 @@ int hubble_init(uint64_t initial_time, const void *key)
 	}
 
 #ifdef CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME
-	/* Counter-based mode: initial_time is the starting counter value */
 	/* 0 is a valid value meaning "start at epoch 0" */
-	eid_initial_counter = initial_time;
+	eid_initial_counter = initial_counter;
+	/* Unix time is optional in this mode; apply it only when provided so
+	 * that hubble_time_get(), satellite pass prediction, and timestamps
+	 * work.
+	 */
+	const bool apply_time = (unix_time != 0U);
 #else
-	/* Unix Epoch-based mode: initial_time is Unix Epoch timestamp in milliseconds */
-	ret = hubble_time_set(initial_time);
-	if (ret != 0) {
-		HUBBLE_LOG_WARNING("Failed to set Unix Epoch time");
-		return ret;
-	}
+	/* Unix-time mode drives the EID counter from unix_time.
+	 * initial_counter is reserved/ignored in this mode.
+	 */
+	(void)initial_counter;
+	const bool apply_time = true;
 #endif
+
+	if (apply_time) {
+		ret = hubble_time_set(unix_time);
+		if (ret != 0) {
+			HUBBLE_LOG_WARNING("Failed to set Unix Epoch time");
+			return ret;
+		}
+	}
 
 	if (key != NULL) {
 		ret = hubble_key_set(key);

--- a/tests/zephyr/ble-network/src/main.c
+++ b/tests/zephyr/ble-network/src/main.c
@@ -69,7 +69,7 @@ ZTEST(ble_nonce_test, test_ble_nonce_invalid)
 
 static void *ble_nonce_test_setup(void)
 {
-	(void)hubble_init(ble_nonce_unix_time, ble_nonce_key);
+	(void)hubble_init(ble_nonce_unix_time, 0, ble_nonce_key);
 
 	testing_adv = false;
 	nonce_idx = 0U;
@@ -140,7 +140,7 @@ ZTEST(ble_adv_test, test_adv_get_overflow)
 
 static void *ble_adv_test_setup(void)
 {
-	(void)hubble_init(ble_adv_unix_time, ble_adv_key);
+	(void)hubble_init(ble_adv_unix_time, 0, ble_adv_key);
 
 	testing_adv = true;
 	nonce_idx = 0U;
@@ -162,7 +162,7 @@ static uint8_t counter_test_key[CONFIG_HUBBLE_KEY_SIZE] = {
 ZTEST(ble_counter_test, test_counter_init_zero)
 {
 	/* In counter mode, 0 is a valid initial counter value */
-	int ret = hubble_init(0, counter_test_key);
+	int ret = hubble_init(0, 0, counter_test_key);
 
 	zassert_ok(ret, "hubble_init with counter=0 should succeed");
 }
@@ -170,7 +170,7 @@ ZTEST(ble_counter_test, test_counter_init_zero)
 ZTEST(ble_counter_test, test_counter_init_nonzero)
 {
 	/* In counter mode, non-zero initial counter should work */
-	int ret = hubble_init(100, counter_test_key);
+	int ret = hubble_init(0, 100, counter_test_key);
 
 	zassert_ok(ret, "hubble_init with counter=100 should succeed");
 }
@@ -178,7 +178,7 @@ ZTEST(ble_counter_test, test_counter_init_nonzero)
 ZTEST(ble_counter_test, test_eid_counter_get)
 {
 	/* Initialize with counter=0 */
-	int ret = hubble_init(0, counter_test_key);
+	int ret = hubble_init(0, 0, counter_test_key);
 
 	zassert_ok(ret, "hubble_init should succeed");
 
@@ -194,8 +194,8 @@ ZTEST(ble_counter_test, test_eid_counter_get)
 ZTEST(ble_counter_test, test_eid_counter_get_with_initial)
 {
 	/* Initialize with counter=50 */
-	const uint64_t initial_counter = 50;
-	int ret = hubble_init(initial_counter, counter_test_key);
+	const uint32_t initial_counter = 50;
+	int ret = hubble_init(0, initial_counter, counter_test_key);
 
 	zassert_ok(ret, "hubble_init should succeed");
 
@@ -210,7 +210,7 @@ ZTEST(ble_counter_test, test_eid_counter_get_with_initial)
 
 ZTEST(ble_counter_test, test_time_to_next_rotation)
 {
-	int ret = hubble_init(0, counter_test_key);
+	int ret = hubble_init(0, 0, counter_test_key);
 
 	zassert_ok(ret, "hubble_init should succeed");
 
@@ -231,7 +231,7 @@ ZTEST(ble_counter_test, test_time_to_next_rotation)
 
 ZTEST(ble_counter_test, test_counter_adv_generation)
 {
-	int ret = hubble_init(0, counter_test_key);
+	int ret = hubble_init(0, 0, counter_test_key);
 
 	zassert_ok(ret, "hubble_init should succeed");
 

--- a/tests/zephyr/hubble-api/src/main.c
+++ b/tests/zephyr/hubble-api/src/main.c
@@ -82,22 +82,22 @@ ZTEST(hubble_api_test, test_init)
 	int err;
 
 	/* Valid init */
-	err = hubble_init(_unix_time, _key);
+	err = hubble_init(_unix_time, 0, _key);
 	zassert_ok(err);
 
 	/* NULL key is accepted; key must be provisioned separately */
-	err = hubble_init(_unix_time, NULL);
+	err = hubble_init(_unix_time, 0, NULL);
 	zassert_ok(err);
 
 	/* It fails when board initialization fails */
 	_board_init_fail = true;
-	err = hubble_init(_unix_time, _key);
+	err = hubble_init(_unix_time, 0, _key);
 	zassert_not_ok(err);
 	_board_init_fail = false;
 
 	/* It fails when crypto initialization fails */
 	_crypto_init_fail = true;
-	err = hubble_init(_unix_time, _key);
+	err = hubble_init(_unix_time, 0, _key);
 	zassert_not_ok(err);
 	_crypto_init_fail = false;
 }
@@ -108,7 +108,7 @@ ZTEST(hubble_api_test, test_init_invalid_time)
 	int err;
 
 	/* Time smaller than current uptime must be rejected */
-	err = hubble_init(1U, _key);
+	err = hubble_init(1U, 0, _key);
 	zassert_not_ok(err);
 #else
 	ztest_test_skip();
@@ -119,7 +119,7 @@ ZTEST(hubble_api_test, test_time_set)
 {
 	int err;
 
-	err = hubble_init(_unix_time, _key);
+	err = hubble_init(_unix_time, 0, _key);
 	zassert_ok(err);
 
 #ifdef CONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME
@@ -142,7 +142,7 @@ ZTEST(hubble_api_test, test_time_get)
 {
 	int err;
 
-	err = hubble_init(_unix_time, _key);
+	err = hubble_init(_unix_time, 0, _key);
 	zassert_ok(err);
 
 #ifdef CONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME
@@ -184,7 +184,7 @@ ZTEST(hubble_api_test, test_counter_get)
 	zassert_not_ok(err);
 #endif
 
-	err = hubble_init(_unix_time, _key);
+	err = hubble_init(_unix_time, 0, _key);
 	zassert_ok(err);
 
 	/* NULL output pointer must be rejected */

--- a/tests/zephyr/sat-api/src/main.c
+++ b/tests/zephyr/sat-api/src/main.c
@@ -228,7 +228,7 @@ static void *sat_test_setup(void)
 {
 	int err;
 
-	err = hubble_init(_unix_time, sat_key);
+	err = hubble_init(_unix_time, 0, sat_key);
 	zassert_ok(err);
 
 	return NULL;

--- a/tests/zephyr/unit/ble-advertise/src/main.c
+++ b/tests/zephyr/unit/ble-advertise/src/main.c
@@ -59,7 +59,7 @@ ZTEST(ble_advertise_test, test_advertise_with_test_vectors)
 		uint64_t unix_time =
 			(uint64_t)tv->time_counter * TIMER_COUNTER_FREQUENCY;
 
-		int ret = hubble_init(unix_time, test_key_primary);
+		int ret = hubble_init(unix_time, 0, test_key_primary);
 		zassert_ok(ret, "hubble_init failed");
 		test_seq_override = tv->seq_no;
 
@@ -86,7 +86,7 @@ ZTEST(ble_advertise_test, test_advertise_with_test_vectors)
 
 ZTEST(ble_advertise_test, test_advertise_null_input_handling)
 {
-	int ret = hubble_init(test_unix_time, test_key_primary);
+	int ret = hubble_init(test_unix_time, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 	test_seq_override = 0;
 
@@ -119,7 +119,7 @@ ZTEST(ble_advertise_test, test_init_allows_deferred_key_argument)
 	uint8_t output[TEST_ADV_BUFFER_SZ];
 	size_t output_len = sizeof(output);
 
-	ret = hubble_init(test_unix_time, NULL);
+	ret = hubble_init(test_unix_time, 0, NULL);
 	zassert_ok(ret, "hubble_init should allow NULL key argument");
 	test_seq_override = 0;
 
@@ -134,7 +134,7 @@ ZTEST(ble_advertise_test, test_advertise_buffer_too_small)
 {
 	uint8_t payload[] = {0x01, 0x02, 0x03, 0x04, 0x05};
 
-	int ret = hubble_init(test_unix_time, test_key_primary);
+	int ret = hubble_init(test_unix_time, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 	test_seq_override = 0;
 
@@ -149,7 +149,7 @@ ZTEST(ble_advertise_test, test_advertise_buffer_too_small)
 
 ZTEST(ble_advertise_test, test_advertise_payload_size_limits)
 {
-	int ret = hubble_init(test_unix_time, test_key_primary);
+	int ret = hubble_init(test_unix_time, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 	test_seq_override = 0;
 
@@ -175,7 +175,7 @@ ZTEST(ble_advertise_test, test_advertise_deterministic)
 {
 	uint8_t payload[] = {0x48, 0x65, 0x6c, 0x6c, 0x6f};
 
-	int ret = hubble_init(test_unix_time, test_key_primary);
+	int ret = hubble_init(test_unix_time, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 	test_seq_override = 100;
 
@@ -207,7 +207,7 @@ ZTEST(ble_advertise_test, test_advertise_time_dependent_output)
 
 	/* Initialize with uptime at 0 */
 	test_uptime_ms = 0;
-	int ret = hubble_init(test_unix_time, test_key_primary);
+	int ret = hubble_init(test_unix_time, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 	test_seq_override = 100;
 
@@ -242,7 +242,7 @@ ZTEST(ble_advertise_test, test_advertise_same_time_different_sequences)
 {
 	uint8_t payload[] = {0xAA, 0xBB};
 
-	int ret = hubble_init(test_unix_time, test_key_primary);
+	int ret = hubble_init(test_unix_time, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 
 	/* Get output with sequence number 0 */
@@ -288,7 +288,7 @@ ZTEST(ble_advertise_format_test, test_service_uuid_present)
 {
 	uint8_t payload[] = {0xAA, 0xBB, 0xCC};
 
-	int ret = hubble_init(test_unix_time, test_key_primary);
+	int ret = hubble_init(test_unix_time, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 	test_seq_override = 0;
 
@@ -308,7 +308,7 @@ ZTEST(ble_advertise_format_test, test_service_uuid_present)
 
 ZTEST(ble_advertise_format_test, test_output_length_calculation)
 {
-	int ret = hubble_init(test_unix_time, test_key_primary);
+	int ret = hubble_init(test_unix_time, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 
 	/* Test different payload lengths */
@@ -343,7 +343,7 @@ ZTEST(ble_advertise_format_test, test_output_length_calculation)
 
 ZTEST(ble_advertise_format_test, test_sequence_number_encoding)
 {
-	int ret = hubble_init(test_unix_time, test_key_primary);
+	int ret = hubble_init(test_unix_time, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 
 	/* Test various sequence numbers */
@@ -399,7 +399,7 @@ ZTEST(ble_advertise_counter_test, test_counter_advertise_with_test_vectors)
 	for (size_t i = 0; i < counter_test_vectors_count; i++) {
 		const struct ble_adv_test_vector *tv = &counter_test_vectors[i];
 
-		int ret = hubble_init(tv->time_counter, test_key_primary);
+		int ret = hubble_init(0, tv->time_counter, test_key_primary);
 		zassert_ok(ret, "hubble_init failed for vector %zu", i);
 
 		test_uptime_ms = 0;
@@ -428,14 +428,14 @@ ZTEST(ble_advertise_counter_test, test_counter_advertise_with_test_vectors)
 ZTEST(ble_advertise_counter_test, test_counter_init_zero_valid)
 {
 	/* In counter mode, 0 is a valid initial counter (unlike Unix Epoch mode) */
-	int ret = hubble_init(0, test_key_primary);
+	int ret = hubble_init(0, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init with counter=0 should succeed");
 }
 
 ZTEST(ble_advertise_counter_test, test_counter_wraps_at_pool_size)
 {
 	/* Init at pool_size - 1 (counter=127 for pool_size=128) */
-	int ret = hubble_init(TEST_COUNTER_POOL_SIZE - 1, test_key_primary);
+	int ret = hubble_init(0, TEST_COUNTER_POOL_SIZE - 1, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 
 	/* Advance one epoch: counter should wrap to 0 */
@@ -450,7 +450,7 @@ ZTEST(ble_advertise_counter_test, test_counter_wraps_at_pool_size)
 	zassert_ok(ret, "advertise_get after wrap failed");
 
 	/* Compare against counter=0 reference (TV1: counter=0, seq=0, empty) */
-	ret = hubble_init(0, test_key_primary);
+	ret = hubble_init(0, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init for reference failed");
 
 	test_uptime_ms = 0;
@@ -471,7 +471,7 @@ ZTEST(ble_advertise_counter_test, test_counter_wraps_at_pool_size)
 
 ZTEST(ble_advertise_counter_test, test_counter_advances_with_uptime)
 {
-	int ret = hubble_init(0, test_key_primary);
+	int ret = hubble_init(0, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 	test_seq_override = 0;
 
@@ -502,7 +502,7 @@ ZTEST(ble_advertise_counter_test, test_counter_advances_with_uptime)
 ZTEST(ble_advertise_counter_test, test_counter_full_wrap)
 {
 	/* Init at counter=0, advance by exactly pool_size epochs */
-	int ret = hubble_init(0, test_key_primary);
+	int ret = hubble_init(0, 0, test_key_primary);
 	zassert_ok(ret, "hubble_init failed");
 	test_seq_override = 0;
 


### PR DESCRIPTION
hubble_init() overloaded a single first argument whose meaning depended on the compile-time counter source: Unix epoch ms in Unix-time mode, or the initial EID counter in device-uptime mode. This made call sites ambiguous and, worse, made it impossible for a device-uptime deployment to also supply a Unix time, even though Unix time is independently useful there for hubble_time_get(), satellite pass prediction, and BLE advertisement timestamps.

Give unix_time and initial_counter their own dedicated arguments so each caller states its intent explicitly, and so device-uptime callers can opt into wall-clock time without changing counter-source semantics. initial_counter is a documented no-op in Unix-time mode, reserved for future use.

All in-repo callers (samples, Zephyr/unit tests, docs) are updated in this same change since this is a breaking signature change.