### PR TITLE
docs: refactor common section and add TI integration guide

### DIFF
--- a/docs/integration_guides/common/account-setup.rst
+++ b/docs/integration_guides/common/account-setup.rst
@@ -1,0 +1,19 @@
+:orphan:
+
+.. hubble-integration-account-setup
+
+Create your Hubble Account
+**************************
+
+A Hubble account is required to access the Hubble Dashboard and generate an
+API key for fetching ephemeris data used in pass prediction.
+
+#. Create an account at the `Hubble Dashboard`_.
+#. Once logged in, follow the `Hubble Platform API documentation`_ to
+   authenticate and generate your API key.
+
+Keep your API key accessible. It is used later in this guide when fetching
+orbital parameters for pass prediction.
+
+.. _Hubble Dashboard: https://dash.hubble.com/create-account
+.. _Hubble Platform API documentation: https://hubble.com/docs/api-specification/hubble-platform-api

--- a/docs/integration_guides/common/data-requirements.rst
+++ b/docs/integration_guides/common/data-requirements.rst
@@ -1,0 +1,63 @@
+:orphan:
+
+.. hubble-integration-data-requirements
+
+Preparing for Satellite Transmission
+*************************************
+
+The satellite stack requires three inputs before it can schedule and transmit:
+
+* **Unix time**: used for pass prediction and key derivation
+* **Device location**: latitude and longitude, used to compute satellite passes
+* **Orbital parameters**: satellite ephemeris data describing each satellite's
+  orbit
+
+How these are provisioned is up to the application.
+
+Time
+====
+
+Many approaches work: BLE provisioning from a phone, NTP over Wi-Fi, GPS, an
+RTC, or reading from persistent storage across reboots. See
+:ref:`hubble_timing` for best practices and trade-offs.
+
+Location
+========
+
+If the device is deployed at a fixed location, latitude and longitude can be
+hard-coded directly in firmware:
+
+.. code-block:: c
+
+   struct hubble_sat_device_pos device_pos = {
+       .lat = 47.6,
+       .lon = -122.3,
+   };
+
+For mobile devices, location can be obtained from an onboard GPS module if
+present, or provisioned at runtime from a companion app. For example,
+delivered over BLE from a phone/gateway that has GPS access.
+
+Orbital Parameters
+==================
+
+Orbital parameters describe each satellite's orbit and are used by
+:c:func:`hubble_sat_next_pass_get` to predict when a satellite will be
+visible from the device location.
+
+Since Hubble satellites are station-keeping, orbital parameters are stable
+enough to be baked into firmware at build time. Use the
+``tools/orbital_params_fetch.py`` helper to fetch current parameters from the
+Hubble API and generate a ``sat_params.c`` file ready to compile into your
+application:
+
+.. code-block:: bash
+
+   export HUBBLE_API_TOKEN=<your-api-token>
+   python tools/orbital_params_fetch.py path/to/output
+
+.. TODO: Add recommended maximum age for baked-in orbital parameters before
+   a firmware update is needed to refresh them.
+
+See :ref:`hubble_satellite_orbital_params` for details on the generated format
+and how to register the array with the SDK.

--- a/docs/integration_guides/common/next-steps.rst
+++ b/docs/integration_guides/common/next-steps.rst
@@ -1,0 +1,58 @@
+:orphan:
+
+.. hubble-integration-next-steps
+
+Next Steps
+**********
+
+RF Verification with an SDR
+============================
+
+Before waiting for a live satellite pass, you can verify that your device is
+transmitting a valid Hubble packet at the physical layer using an
+`ADALM-PLUTO product page`_ and the `pyhubblenetwork`_ Python library.
+
+Install the library:
+
+.. code-block:: bash
+
+   pip install pyhubblenetwork
+
+Connect the ADALM-PLUTO near the device antenna and run the scanner with your
+device key to decode captured packets in real time:
+
+.. code-block:: bash
+
+   hubblenetwork sat scan --key "<your-device-key>"
+
+A successfully decoded packet confirms the RF output, packet framing, channel
+hopping sequence, and PA/FEM sequencing are all correct. For the full list of
+available commands, run:
+
+.. code-block:: bash
+
+   hubblenetwork --help
+
+See the `pyhubblenetwork`_ repository for detailed usage and setup
+instructions.
+
+Viewing Upcoming Passes
+========================
+
+Use the `Hubble Pass Explorer`_ to see when the next satellite pass is predicted
+for your location. This is useful to cross-check pass prediction results from the
+device and to plan test windows.
+
+Dashboard Verification
+======================
+
+Once a live satellite pass has occurred and :c:func:`hubble_sat_packet_send`
+returned without error, after the downlink data is successful, log into the
+`Hubble Dashboard Devices Page`_ to confirm the packet was received by the network. A packet
+appearing on the dashboard is end-to-end proof that the device is operational
+on the Hubble satellite network.
+
+.. _pyhubblenetwork: https://github.com/HubbleNetwork/pyhubblenetwork
+.. _ADALM-PLUTO product page: https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/adalm-pluto.html#eb-overview
+.. _Hubble Pass Explorer: https://dash.hubble.com/satellite/pass-explorer
+.. _Hubble Dashboard Devices Page: https://dash.hubble.com/devices

--- a/docs/integration_guides/common/pass-prediction.rst
+++ b/docs/integration_guides/common/pass-prediction.rst
@@ -1,0 +1,37 @@
+:orphan:
+
+.. hubble-integration-pass-prediction
+
+With the SDK initialized, the application enters the main dual-stack loop:
+compute the next satellite pass, beacon over BLE while waiting, stop BLE,
+transmit to the satellite, then repeat.
+
+Compute the Next Pass
+=====================
+
+.. code-block:: c
+
+   for (;;) {
+       now_ms = hubble_time_get();
+
+       err = hubble_sat_next_pass_get(now_ms, &device_pos, &pass_info);
+       if (err != 0) {
+           LOG_ERR("Failed to get next pass (err %d)", err);
+           return err;
+       }
+
+       /* If the pass has already started, find the next one. */
+       if (pass_info.start <= now_ms) {
+           err = hubble_sat_next_pass_get(
+               pass_info.start + pass_info.duration,
+               &device_pos, &pass_info);
+           if (err != 0) {
+               LOG_ERR("Failed to get next pass (err %d)", err);
+               return err;
+           }
+       }
+
+:c:func:`hubble_sat_next_pass_get` returns the soonest pass visible from the
+device location. If ``pass_info.start`` is already in the past, a pass is in
+progress, skip it and compute the next one by searching from after its end
+(``pass_info.start + pass_info.duration``).

--- a/docs/integration_guides/common/prerequisites.rst
+++ b/docs/integration_guides/common/prerequisites.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+.. hubble-integration-prerequisites
+
+Prerequisites
+*************
+
+Before starting, ensure you have the following:
+
+* **A supported development kit or custom board** with a PA or FEM capable of
+  at least +20 dBm transmit output power. The Hubble satellite link budget
+  requires this minimum output to reach the network reliably.
+* **An antenna tuned to the Hubble satellite frequency band**, connected to
+  the RF output of the PA or FEM.
+* **A Hubble account and API key** to fetch ephemeris data for pass prediction.
+* **ADALM-PLUTO SDR** *(optional, recommended for custom board bring-up)*:
+  used to verify RF output at the physical layer. Available from common
+  distributors such as DigiKey and Mouser. See the `ADALM-PLUTO product page`_
+  for details.
+
+.. _ADALM-PLUTO product page: https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/adalm-pluto.html#eb-overview

--- a/docs/integration_guides/common/sdk-init.rst
+++ b/docs/integration_guides/common/sdk-init.rst
@@ -1,0 +1,41 @@
+:orphan:
+
+.. hubble-integration-sdk-init
+
+Initializing the Hubble Device SDK
+***********************************
+
+Once time, location, and orbital parameters are available, initialize the SDK
+before calling any other Hubble API:
+
+.. code-block:: c
+
+   /*
+    * At this point unix_time_ms, device_pos, and orb_params are assumed to be
+    * valid. Either baked into firmware or received via BLE provisioning.
+    */
+   err = hubble_init(unix_time_ms, master_key);
+   if (err != 0) {
+       LOG_ERR("Failed to initialize Hubble Device SDK (err %d)", err);
+       return err;
+   }
+
+   err = hubble_sat_satellites_set(orb_params, orb_params_count);
+   if (err != 0) {
+       LOG_ERR("Failed to set orbital parameters (err %d)", err);
+       return err;
+   }
+
+:c:func:`hubble_init` takes the current Unix time in milliseconds and a
+pointer to the master key. :c:func:`hubble_sat_satellites_set` registers the
+orbital parameters array with the SDK.
+
+.. warning::
+
+   * **The key buffer MUST remain valid for the lifetime of SDK usage.** The
+     SDK stores the pointer directly and does not copy the key. Do not use a
+     stack or temporary buffer.
+   * **Unix time must be non-zero.** Passing ``0`` in
+     ``CONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME`` mode returns an error.
+   * **The orbital parameters array MUST remain valid** for as long as pass
+     prediction is used. The SDK stores a pointer and does not copy the array.

--- a/docs/integration_guides/common/troubleshooting-common.rst
+++ b/docs/integration_guides/common/troubleshooting-common.rst
@@ -1,0 +1,61 @@
+:orphan:
+
+.. hubble-integration-troubleshooting-common
+
+``hubble_init`` returns an error
+=================================
+
+**Symptom:** ``<wrn> hubblenetwork: Failed to set Unix Epoch time``
+
+**Cause:** ``unix_time_ms`` passed to :c:func:`hubble_init` is ``0``.
+The SDK requires a valid non-zero Unix timestamp.
+
+**Fix:** Ensure time is provisioned (over BLE, NTP, GPS, or RTC) before
+calling :c:func:`hubble_init`. See the **Preparing for Satellite
+Transmission** section in this guide.
+
+---
+
+**Symptom:** ``<wrn> hubblenetwork: Failed to set key``
+
+**Cause:** The key buffer is NULL, zero-length, or the wrong size for the
+configured key type.
+
+**Fix:** Verify the key is correctly decoded and its length matches the
+configured key size.
+
+Pass prediction returns an error
+=================================
+
+**Symptom:** ``<wrn> hubblenetwork: Hubble Satellite next pass get: no satellites configured``
+
+**Cause:** :c:func:`hubble_sat_satellites_set` was not called before
+:c:func:`hubble_sat_next_pass_get`.
+
+**Fix:** Call :c:func:`hubble_sat_satellites_set` with a valid orbital
+parameters array immediately after :c:func:`hubble_init`.
+
+---
+
+**Symptom:** ``<wrn> hubblenetwork: Hubble Satellite next pass get: no pass found``
+
+**Cause:** No satellite pass is visible from the given location within the
+search window. Most commonly caused by incorrect device coordinates or a
+stale Unix timestamp.
+
+**Fix:** Verify that ``device_pos.lat`` and ``device_pos.lon`` are correct
+and that ``unix_time_ms`` reflects current wall-clock time.
+
+---
+
+**Symptom:** Firmware appears to hang or stall inside
+:c:func:`hubble_sat_next_pass_get`.
+
+**Cause:** The pass prediction algorithm iterates forward orbit-by-orbit until
+it finds a pass. If the input time is near zero (e.g. Unix time was passed in
+**seconds** instead of **milliseconds**), or if ``device_pos.lat``
+and ``device_pos.lon`` are invalid, the loop can spin through thousands of
+orbits before returning.
+
+**Fix:** Confirm ``unix_time_ms`` is in **milliseconds** and that
+``device_pos.lat`` and ``device_pos.lon`` hold the actual device coordinates.

--- a/docs/integration_guides/index.rst
+++ b/docs/integration_guides/index.rst
@@ -7,3 +7,4 @@ Integration Guides
    :maxdepth: 1
 
    ncs/index
+   ti/index

--- a/docs/integration_guides/ncs/index.rst
+++ b/docs/integration_guides/ncs/index.rst
@@ -46,38 +46,11 @@ board API implementations for the following development kits out of the box:
 For custom boards, refer to the :ref:`board bring-up <ncs_sat_board_bringup>`
 section.
 
-Prerequisites
-*************
+.. include:: ../common/prerequisites.rst
+   :start-after: hubble-integration-prerequisites
 
-Before starting, ensure you have the following:
-
-* **A supported development kit or custom board** with a PA or FEM capable of
-  at least +20 dBm transmit output power. The Hubble satellite link budget
-  requires this minimum output to reach the network reliably.
-* **An antenna tuned to the Hubble satellite frequency band**, connected to
-  the RF output of the PA or FEM.
-* **A Hubble account and API key** to fetch ephemeris data for pass prediction.
-  See :ref:`Create your Hubble Account <ncs_sat_hubble_account>` below.
-* **ADALM-PLUTO SDR** *(optional, recommended for custom board bring-up)*:
-  used to verify RF output at the physical layer. Available from common
-  distributors such as DigiKey and Mouser. See the `ADALM-PLUTO product page`_
-  for details, and :ref:`Next Steps <ncs_sat_next_steps>` for the verification
-  workflow.
-
-.. _ncs_sat_hubble_account:
-
-Create your Hubble Account
-**************************
-
-A Hubble account is required to access the Hubble Dashboard and generate an
-API key for fetching ephemeris data used in pass prediction.
-
-#. Create an account at the `Hubble Dashboard`_.
-#. Once logged in, follow the `Hubble Platform API documentation`_ to
-   authenticate and generate your API key.
-
-Keep your API key accessible. It is used later in this guide when fetching
-orbital parameters for pass prediction.
+.. include:: ../common/account-setup.rst
+   :start-after: hubble-integration-account-setup
 
 SDK Setup
 *********
@@ -346,148 +319,19 @@ Other common options for a dual-stack application:
    CONFIG_FPU=y
 
 
-.. _ncs_sat_data_requirements:
-
-Preparing for Satellite Transmission
-*************************************
-
-The satellite stack requires three inputs before it can schedule and transmit:
-
-* **Unix time**: used for pass prediction and key derivation
-* **Device location**: latitude and longitude, used to compute satellite passes
-* **Orbital parameters**: satellite ephemeris data describing each satellite's
-  orbit
-
-How these are provisioned is up to the application.
-
-Time
-====
-
-Many approaches work: BLE provisioning from a phone, NTP over Wi-Fi, GPS, an
-RTC, or reading from persistent storage across reboots. See
-:ref:`hubble_timing` for best practices and trade-offs.
-
-Location
-========
-
-If the device is deployed at a fixed location, latitude and longitude can be
-hard-coded directly in firmware:
-
-.. code-block:: c
-
-   struct hubble_sat_device_pos device_pos = {
-       .lat = 47.6,
-       .lon = -122.3,
-   };
-
-For mobile devices, location can be obtained from an onboard GPS module if
-present, or provisioned at runtime from a companion app. For example,
-delivered over BLE from a phone/gateway that has GPS access.
-
-Orbital Parameters
-==================
-
-Orbital parameters describe each satellite's orbit and are used by
-:c:func:`hubble_sat_next_pass_get` to predict when a satellite will be
-visible from the device location.
-
-Since Hubble satellites are station-keeping, orbital parameters are stable
-enough to be baked into firmware at build time. Use the
-``tools/orbital_params_fetch.py`` helper to fetch current parameters from the
-Hubble API and generate a ``sat_params.c`` file ready to compile into your
-application:
-
-.. code-block:: bash
-
-   export HUBBLE_API_TOKEN=<your-api-token>
-   python tools/orbital_params_fetch.py path/to/output
-
-.. TODO: Add recommended maximum age for baked-in orbital parameters before
-   a firmware update is needed to refresh them.
-
-See :ref:`hubble_satellite_orbital_params` for details on the generated format and
-how to register the array with the SDK.
+.. include:: ../common/data-requirements.rst
+   :start-after: hubble-integration-data-requirements
 
 
-Initializing the Hubble Device SDK
-**********************************
-
-Once time, location, and orbital parameters are available, initialize the SDK
-before calling any other Hubble API:
-
-.. code-block:: c
-
-   /*
-    * At this point unix_time_ms, device_pos, and orb_params are assumed to be
-    * valid. Either baked into firmware or received via BLE provisioning.
-    */
-   err = hubble_init(unix_time_ms, master_key);
-   if (err != 0) {
-       LOG_ERR("Failed to initialize Hubble Device SDK (err %d)", err);
-       return err;
-   }
-
-   err = hubble_sat_satellites_set(orb_params, orb_params_count);
-   if (err != 0) {
-       LOG_ERR("Failed to set orbital parameters (err %d)", err);
-       return err;
-   }
-
-:c:func:`hubble_init` takes the current Unix time in milliseconds and a
-pointer to the master key. :c:func:`hubble_sat_satellites_set` registers the
-orbital parameters array with the SDK.
-
-.. warning::
-
-   * **The key buffer MUST remain valid for the lifetime of SDK usage.** The
-     SDK stores the pointer directly and does not copy the key. Do not use a
-     stack or temporary buffer.
-   * **Unix time must be non-zero.** Passing ``0`` in
-     ``CONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME`` mode returns an error.
-   * **The orbital parameters array MUST remain valid** for as long as pass
-     prediction is used. The SDK stores a pointer and does not copy the array.
+.. include:: ../common/sdk-init.rst
+   :start-after: hubble-integration-sdk-init
 
 
 The Pass Prediction Loop
 ************************
 
-With the SDK initialized, the application enters the main dual-stack loop:
-compute the next satellite pass, beacon over BLE while waiting, stop BLE,
-transmit to the satellite, then repeat.
-
-Compute the Next Pass
-=====================
-
-.. code-block:: c
-
-   /*
-    * Before this loop, make sure that the Bluetooth stack has been
-    * properly initialized by calling bt_init()
-    */
-   for (;;) {
-       now_ms = hubble_time_get();
-
-       err = hubble_sat_next_pass_get(now_ms, &device_pos, &pass_info);
-       if (err != 0) {
-           LOG_ERR("Failed to get next pass (err %d)", err);
-           return err;
-       }
-
-       /* If the pass has already started, find the next one. */
-       if (pass_info.start <= now_ms) {
-           err = hubble_sat_next_pass_get(
-               pass_info.start + pass_info.duration,
-               &device_pos, &pass_info);
-           if (err != 0) {
-               LOG_ERR("Failed to get next pass (err %d)", err);
-               return err;
-           }
-       }
-
-:c:func:`hubble_sat_next_pass_get` returns the soonest pass visible from the
-device location. If ``pass_info.start`` is already in the past, a pass is in
-progress, skip it and compute the next one by searching from after its end
-(``pass_info.start + pass_info.duration``).
+.. include:: ../common/pass-prediction.rst
+   :start-after: hubble-integration-pass-prediction
 
 Beacon over BLE While Waiting
 ==============================
@@ -624,63 +468,8 @@ radio library.
 
    west blobs fetch hubblenetwork-sdk
 
-``hubble_init`` returns an error
-=================================
-
-**Symptom:** ``<wrn> hubblenetwork: Failed to set Unix Epoch time``
-
-**Cause:** ``unix_time_ms`` passed to :c:func:`hubble_init` is ``0``.
-The SDK requires a valid non-zero Unix timestamp.
-
-**Fix:** Ensure time is provisioned (over BLE, NTP, GPS, or RTC) before
-calling :c:func:`hubble_init`. See :ref:`ncs_sat_data_requirements`.
-
----
-
-**Symptom:** ``<wrn> hubblenetwork: Failed to set key``
-
-**Cause:** The key buffer is NULL, zero-length, or the wrong size for the
-configured key type (``CONFIG_HUBBLE_NETWORK_KEY_128`` or
-``CONFIG_HUBBLE_NETWORK_KEY_256``).
-
-**Fix:** Verify the key is correctly decoded and its length matches
-``CONFIG_HUBBLE_KEY_SIZE``.
-
-Pass prediction returns an error
-=================================
-
-**Symptom:** ``<wrn> hubblenetwork: Hubble Satellite next pass get: no satellites configured``
-
-**Cause:** :c:func:`hubble_sat_satellites_set` was not called before
-:c:func:`hubble_sat_next_pass_get`.
-
-**Fix:** Call :c:func:`hubble_sat_satellites_set` with a valid orbital
-parameters array immediately after :c:func:`hubble_init`.
-
----
-
-**Symptom:** ``<wrn> hubblenetwork: Hubble Satellite next pass get: no pass found``
-
-**Cause:** No satellite pass is visible from the given location within the
-search window. Most commonly caused by incorrect device coordinates or a
-stale Unix timestamp.
-
-**Fix:** Verify that ``device_pos.lat`` and ``device_pos.lon`` are correct
-and that ``unix_time_ms`` reflects current wall-clock time.
-
----
-
-**Symptom:** Firmware appears to hang or stall inside
-:c:func:`hubble_sat_next_pass_get`.
-
-**Cause:** The pass prediction algorithm iterates forward orbit-by-orbit until
-it finds a pass. If the input time is near zero (e.g. Unix time was passed in
-**seconds** instead of **milliseconds**), or if ``device_pos.lat``
-and ``device_pos.lon`` are invalid, the loop can spin
-through thousands of orbits before returning.
-
-**Fix:** Confirm ``unix_time_ms`` is in **milliseconds** and that
-``device_pos.lat`` and ``device_pos.lon`` hold the actual device coordinates.
+.. include:: ../common/troubleshooting-common.rst
+   :start-after: hubble-integration-troubleshooting-common
 
 Transmission fails
 ==================
@@ -709,55 +498,8 @@ board implementation.
 
 .. _ncs_sat_next_steps:
 
-Next Steps
-**********
-
-RF Verification with an SDR
-============================
-
-Before waiting for a live satellite pass, you can verify that your device is
-transmitting a valid Hubble packet at the physical layer using an
-`ADALM-PLUTO product page`_ and the `pyhubblenetwork`_ Python library.
-
-Install the library:
-
-.. code-block:: bash
-
-   pip install pyhubblenetwork
-
-Connect the ADALM-PLUTO near the device antenna and run the scanner with your
-device key to decode captured packets in real time:
-
-.. code-block:: bash
-
-   hubblenetwork sat scan --key "<your-device-key>"
-
-A successfully decoded packet confirms the RF output, packet framing, channel
-hopping sequence, and PA/FEM sequencing are all correct. For the full list of
-available commands, run:
-
-.. code-block:: bash
-
-   hubblenetwork --help
-
-See the `pyhubblenetwork`_ repository for detailed usage and setup
-instructions.
-
-Viewing Upcoming Passes
-========================
-
-Use the **Hubble Pass Explorer** on the `Hubble Dashboard`_ to see when the
-next satellite pass is predicted for your location. This is useful to
-cross-check pass prediction results from the device and to plan test windows.
-
-Dashboard Verification
-======================
-
-Once a live satellite pass has occurred and :c:func:`hubble_sat_packet_send`
-returned without error, after the downlink data is successful, log into the
-`Hubble Dashboard`_ to confirm the packet was received by the network. A packet
-appearing on the dashboard is end-to-end proof that the device is operational
-on the Hubble satellite network.
+.. include:: ../common/next-steps.rst
+   :start-after: hubble-integration-next-steps
 
 Further Reading
 ===============
@@ -775,9 +517,5 @@ Further Reading
 
 .. _NCS installation guide: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation/install_ncs.html
 .. _nRF Connect SDK: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html
-.. _ADALM-PLUTO product page: https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/adalm-pluto.html#eb-overview
-.. _pyhubblenetwork: https://github.com/HubbleNetwork/pyhubblenetwork
-.. _Hubble Dashboard: https://dash.hubble.com/create-account
-.. _Hubble Platform API documentation: https://hubble.com/docs/api-specification/hubble-platform-api
 .. _Zephyr board porting guide: https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html
 .. _Hubble Thingy\:53 reference application: https://github.com/HubbleNetwork/hubble-reference-thingy53

--- a/docs/integration_guides/ti/index.rst
+++ b/docs/integration_guides/ti/index.rst
@@ -1,0 +1,474 @@
+.. _ti_integration_guide:
+
+TI SimpleLink Integration Guide
+################################
+
+This guide walks through integrating the Hubble Network dual-stack Satellite
+and BLE application with the `TI SimpleLink Low Power F3 SDK`_.
+
+By the end of this guide you will know how to:
+
+* Integrate the Hubble Satellite and Terrestrial (BLE) network stacks into a
+  TI SimpleLink application.
+* Obtain ephemeris data and use pass prediction to schedule satellite
+  transmissions.
+* Transmit data to the Hubble satellite network from a TI device.
+
+Supported Devices and SDK Version
+**********************************
+
+The Hubble Device SDK currently supports **SimpleLink Low Power F3 SDK v9.20**.
+If you require support for a different version, `contact us <mailto:support@hubble.com>`_.
+
+The following TI SimpleLink device families are supported:
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Device
+     - Family
+     - Notes
+   * - CC2340R5
+     - CC23xx
+     - Max 8 dBm; external amplifier required to reach 20 dBm
+   * - CC2755P10
+     - CC27xx
+     - 20 dBm integrated PA
+
+The following toolchain versions are validated against
+**SimpleLink Low Power F3 SDK v9.20.00.81**. See the
+`SimpleLink Low Power F3 SDK v9.20.00.81 release notes`_ for the full
+compatibility matrix. For other patch or build versions, refer to their
+respective release notes.
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Tool
+     - Version
+   * - Code Composer Studio
+     - 20.4.0
+   * - TI ARM Clang Compiler
+     - 4.0.4.LTS
+   * - SysConfig
+     - 1.26.3
+   * - UniFlash
+     - 9.5.0
+
+
+.. include:: ../common/prerequisites.rst
+   :start-after: hubble-integration-prerequisites
+
+.. include:: ../common/account-setup.rst
+   :start-after: hubble-integration-account-setup
+
+
+SDK Setup
+*********
+
+Clone the Hubble Device SDK:
+
+.. code-block:: bash
+
+   git clone https://github.com/HubbleNetwork/hubble-device-sdk.git
+
+Adding the Hubble Device SDK to SysConfig
+==========================================
+
+The steps below cover both **Code Composer Studio (CCS)** and a
+Makefile-based workflow.
+
+.. tabs::
+
+   .. tab:: CCS
+
+      If you do not have a CCS project yet, refer to the
+      `TI CCS Getting Started guide`_ for instructions on creating one.
+
+      #. Right-click your project folder and select **Properties**.
+      #. Navigate to **Build** → **Tools** → **SysConfig**.
+      #. In the **SysConfig Flags** field, append:
+
+         .. code-block:: none
+
+            -s "/path/to/hubble-device-sdk/.metadata/product.json"
+
+      #. Click the checkmark to confirm, then **Save and Close**.
+
+   .. tab:: Makefile
+
+      Set the following environment variables before building:
+
+      .. code-block:: bash
+
+         export TICLANG_ARMCOMPILER=/path/to/ti-cgt-armllvm
+         export SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR=/path/to/simplelink_lowpower_f3_sdk
+         export SYSCONFIG_TOOL=/path/to/sysconfig_cli.sh
+         export HUBBLE_NETWORK_SDK=/path/to/hubble-device-sdk
+
+      Pass both product descriptors to the SysConfig CLI:
+
+      .. code-block:: Makefile
+
+         SYSCFG_CMD_STUB = $(SYSCONFIG_TOOL) --compiler ticlang \
+             --product $(SIMPLELINK_LOWPOWER_F3_SDK_INSTALL_DIR)/.metadata/product.json \
+             -s $(HUBBLE_NETWORK_SDK)/.metadata/product.json
+
+      Generate the configuration files into your build directory:
+
+      .. code-block:: Makefile
+
+         SYSCFG_FILES := $(shell $(SYSCFG_CMD_STUB) \
+             --listGeneratedFiles --listReferencedFiles \
+             --output $(BUILD_DIR) your-app.syscfg)
+
+         SYSCFG_C_FILES   = $(filter %.c,$(SYSCFG_FILES))
+         SYSCFG_H_FILES   = $(filter %.h,$(SYSCFG_FILES))
+         SYSCFG_OPT_FILES = $(filter %.opt,$(SYSCFG_FILES))
+
+      Pass the generated ``.opt`` files to the compiler:
+
+      .. code-block:: Makefile
+
+         CFLAGS += $(addprefix @,$(SYSCFG_OPT_FILES))
+
+      Besides this, you will need to pull in the correct header and source files
+      from TI SimpleLink. See ``samples/freertos/ti/sat-dual-stack`` for a complete
+      reference Makefile for each target device.
+
+
+.. _ti_sat_project_config:
+
+Project Configuration
+*********************
+
+Enable the Hubble dual-stack functionality by adding Hubble configuration
+options to your project's ``.syscfg`` file.
+
+.. tabs::
+
+   .. tab:: CCS
+
+      #. Double-click your project's ``.syscfg`` file to open it in the
+         SysConfig editor.
+      #. In the left pane, scroll to the bottom and locate
+         **HUBBLE DEVICE SDK**. Click **+** to add it.
+      #. Check **Enable Hubble Satellite Network** and
+         **Enable Hubble Terrestrial Network**.
+      #. Set **Device time drift retry rate in PPM** to your oscillator's
+         PPM rating (check your crystal datasheet). See
+         :ref:`hubble_satellite_clock_drift` for details.
+      #. **Use FreeRTOS Daemon Hook** is enabled by default to automatically
+         set up the BLE and satellite stacks. If you disable it, you must call
+         :c:func:`hubble_init` in your application **before** the BLE stack is
+         started. More details are in the :ref:`ti_sat_sdk_init` section.
+      #. Hover over the **(?)** icon next to each option to learn more, or
+         refer to :ref:`hubble_configuration` for the complete options
+         reference.
+      #. Save the file, then right-click it → **Open With...** → **Text
+         Editor** and add the following at the bottom to enable
+         both BLE and satellite stacks:
+
+         .. code-block:: javascript
+
+            var hubble_radio = system.getScript("/hubble_radio.js");
+            hubble_radio.config_dual_stack("ble");
+
+   .. tab:: Makefile
+
+      Add the following to your ``.syscfg`` file. ``hubble_radio.js`` sets
+      up the ``radioconfig`` and the Dynamic Multi-protocol Manager (DMM)
+      so the BLE and satellite stacks can share the radio:
+
+      .. code-block:: javascript
+
+         var Hubble = scripting.addModule("/Hubble");
+         Hubble.useSatellite   = true;
+         Hubble.useTerrestrial = true;
+         /* Set to your oscillator's PPM rating (check your crystal datasheet) */
+         Hubble.deviceTDR      = 10;
+
+         var hubble_radio = system.getScript("/hubble_radio.js");
+         hubble_radio.config_dual_stack("ble");
+
+      Then set the following in your application's ``hubble_config.h``, which
+      you need to include along with your source files in the Makefile:
+
+      .. code-block:: c
+
+         #define CONFIG_HUBBLE_SAT_NETWORK              1
+         #define CONFIG_HUBBLE_BLE_NETWORK              1
+         #define CONFIG_HUBBLE_KEY_SIZE                 16 /* 16 for 128-bit, 32 for 256-bit */
+         #define CONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME 1
+         #define CONFIG_HUBBLE_SAT_NETWORK_DEVICE_TDR   10 /* Check your oscillator's PPM rating */
+
+      See :ref:`hubble_satellite_clock_drift` for details on TDR and how
+      it affects retransmissions.
+
+      Optionally, enable the Hubble FreeRTOS daemon hook to automatically
+      set up the BLE and satellite stacks.
+
+      .. code-block:: c
+
+         #define CONFIG_HUBBLE_FREERTOS_DAEMON_HOOK 1
+
+.. note::
+
+   **Crypto:** A custom AES-CMAC and AES-CTR implementation is required.
+   Make sure to select the correct crypto options in your ``.syscfg`` file.
+   See ``src/hubble_ti_crypto.c`` in the Hubble samples for a reference
+   implementation.
+
+.. note::
+
+   Make sure the RCL command symbol in the custom RF settings is generated
+   automatically (set **Symbol Name Generation Method** to **Automatic**).
+   See ``samples/freertos/ti/sat-dual-stack`` for complete reference
+   ``.syscfg`` scripts.
+
+.. include:: ../common/data-requirements.rst
+   :start-after: hubble-integration-data-requirements
+
+
+.. _ti_sat_sdk_init:
+
+.. include:: ../common/sdk-init.rst
+   :start-after: hubble-integration-sdk-init
+
+If ``CONFIG_HUBBLE_FREERTOS_DAEMON_HOOK`` is disabled, :c:func:`hubble_init`
+must be called **before** ``BLEAppUtil_init``:
+
+.. code-block:: c
+
+   /* Hardware initialization: Board_init(), clocks, peripherals, etc. */
+
+   /*
+    * unix_time_ms must be > device uptime in CONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME
+    * mode. We can use UINT64_MAX as a sentinel value until real Unix time is provisioned.
+    */
+   hubble_init(UINT64_MAX, master_key);
+
+   /* Update user configuration of the BLE stack */
+   user0Cfg.appServiceInfo->timerTickPeriod     = ICall_getTickPeriod();
+   user0Cfg.appServiceInfo->timerMaxMillisecond = ICall_getMaxMSecs();
+
+   BLEAppUtil_init(&criticalErrorHandler, &App_StackInitDoneHandler,
+                   &appMainParams, &appMainPeriCentParams);
+
+Once real Unix time and orbital parameters are available (e.g. provisioned
+over BLE), call :c:func:`hubble_sat_satellites_set` before starting pass
+prediction.
+
+
+The Pass Prediction Loop
+************************
+
+.. include:: ../common/pass-prediction.rst
+   :start-after: hubble-integration-pass-prediction
+
+Beacon over BLE While Waiting
+==============================
+
+Schedule a timer for the pass window and start BLE advertising while the
+device waits. The example below uses ``ClockP``; any timer peripheral that
+can schedule a future callback works equally well.
+
+.. code-block:: c
+
+       /*
+        * Schedule a ClockP timer for the satellite pass window.
+        * Verify configTICK_RATE_HZ: the sleep duration must not exceed
+        * the maximum timeout ClockP supports at your tick rate.
+         */
+       ClockP_setTimeout(&satPassClock,
+                         ClockP_usToTicks((pass_info.start - now_ms) * 1000U));
+       ClockP_start(&satPassClock);
+
+       /* Get the Hubble beacon payload and start advertising */
+       hubble_ble_advertise_get(inputBuf, inputBufLen, outBuf, &outBufLen);
+       ble_adv_start();
+
+       /*
+        * Block until the pass timer fires. Common approaches are
+        * a semaphore, task notification, or event flag.
+        */
+       SemaphoreP_pend(&satPassSem, SemaphoreP_WAIT_FOREVER);
+
+Transmit to the Satellite
+==========================
+
+Stop advertising, then build and send the packet:
+
+.. code-block:: c
+
+       ble_adv_stop();
+
+       err = hubble_sat_packet_get(&packet, NULL, 0);
+       if (err != 0) {
+           LOG_ERR("Failed to build packet (err %d)", err);
+           return err;
+       }
+
+       /* Blocking call. Retries are handled internally by the SDK */
+       err = hubble_sat_packet_send(&packet, HUBBLE_SAT_RELIABILITY_NORMAL);
+       if (err != 0) {
+           LOG_ERR("Failed to send packet (err %d)", err);
+           return err;
+       }
+   } /* end while loop, back to compute the next pass, re-enable bluetooth, and beacon */
+
+:c:func:`hubble_sat_packet_send` is blocking. It returns only after the full
+transmission sequence completes, including all retries. See
+:ref:`hubble_satellite_reliability` for guidance on reliability modes and
+their effect on power consumption.
+
+.. note::
+
+   ``BLEAppUtil_advStart`` and ``BLEAppUtil_advStop`` must be called from
+   within the BLEAppUtil context. Calling them directly from another thread
+   will cause a crash or silently fail.
+   Use ``BLEAppUtil_invokeFunction`` to put the call into the correct context:
+
+   .. code-block:: c
+
+      bStatus_t ble_adv_start(void)
+      {
+          return BLEAppUtil_invokeFunction(
+              (InvokeFromBLEAppUtilContext_t)_beacon_start, NULL);
+      }
+
+      bStatus_t ble_adv_stop(void)
+      {
+          return BLEAppUtil_invokeFunction(
+              (InvokeFromBLEAppUtilContext_t)_beacon_stop, NULL);
+      }
+
+   where ``_beacon_start`` calls
+   ``BLEAppUtil_advStart(_beacon_adv_handle, &_hubble_start_adv_set)``
+   and ``_beacon_stop`` calls ``BLEAppUtil_advStop(_beacon_adv_handle)``.
+   See ``samples/freertos/ti/sat-dual-stack`` for a complete reference
+   implementation.
+
+
+Building and Flashing
+*********************
+
+.. tabs::
+
+   .. tab:: CCS
+
+      #. Right-click your project in the **Project Explorer** and select
+         **Build Project** (or use **Project** → **Build Project** from the
+         menu bar).
+      #. Once the build succeeds, right-click the project and select
+         **Flash Project** to flash the firmware to the device.
+
+   .. tab:: Makefile
+
+      Build your application by invoking the Makefile:
+
+      .. code-block:: bash
+
+         make -f <your-makefile>
+
+      To flash, use `UniFlash`_. Connect your device and
+      load the built ``.hex`` or ``.out`` file.
+
+.. note::
+
+   **CC2755P10 (CC27xx):** If the Hardware Security Module (HSM) has not
+   been provisioned on your device yet, BLE may not function correctly.
+   Refer to the `TI SimpleLink CC27xx Getting Started guide`_ for
+   instructions on loading the HSM before running your application.
+
+
+Verifying the Application
+**************************
+
+Unlike other ports, the TI port does not include a logging backend built in
+for Hubble Device SDK log. Verification is done using external tools, or
+enabling logging module and calling log functions manually in your application.
+
+Verify BLE
+==========
+
+Use the SDK's scan script to confirm BLE advertising is working. Install the
+dependencies and run:
+
+.. code-block:: bash
+
+   pip install -r tools/requirements-scan.txt
+   python tools/scan.py --key "<your-device-key>"
+
+The script scans for Hubble BLE beacons (UUID 0xFCA6) and prints decoded
+packets in real time. Running without ``--key`` prints raw packets without
+decryption.
+
+Alternatively, use the **Hubble Connect** mobile app to see nearby Hubble
+devices:
+
+* `Hubble Connect on the App Store`_
+* `Hubble Connect on Google Play`_
+
+Verify Satellite RF
+===================
+
+To verify the satellite RF output before a live pass, use an ADALM-PLUTO SDR
+and the ``pyhubblenetwork`` scan tool. See the **RF Verification with an SDR**
+section in **Next Steps** below for full instructions.
+
+
+Troubleshooting
+***************
+
+.. include:: ../common/troubleshooting-common.rst
+   :start-after: hubble-integration-troubleshooting-common
+
+Transmission fails
+==================
+
+**Symptom:** :c:func:`hubble_sat_packet_send` returns an error or BLE
+silently fails to send any advertising packets.
+
+**Cause:**
+
+* ``BLEAppUtil_advStop`` or ``BLEAppUtil_advStart`` was not called from
+  within the ``BLEAppUtil`` context.
+
+* Stack is too tight: the call stack needs to have enough space
+  to handle both BLE and satellite stack operations.
+
+**Fix:**
+
+* Verify the return status of ``BLEAppUtil_invokeFunction``.
+
+* Increase the stack size of the task that calls ``hubble_sat_packet_send``,
+  pass prediction API, or BLE advertising start/stop.
+
+
+.. _ti_sat_next_steps:
+
+.. include:: ../common/next-steps.rst
+   :start-after: hubble-integration-next-steps
+
+Further Reading
+===============
+
+* :ref:`hubble_satellite_introduction`: satellite protocol details,
+  reliability modes, and power trade-offs.
+* :ref:`hubble_configuration`: full configuration reference for all
+  ``CONFIG_HUBBLE_*`` options.
+* :ref:`hubble_timing`: time management best practices for devices
+  with and without a real-time clock.
+* `TI SimpleLink Low Power F3 SDK`_: TI's SDK documentation, examples, and release notes.
+
+
+.. _TI SimpleLink Low Power F3 SDK: https://www.ti.com/tool/download/SIMPLELINK-LOWPOWER-F3-SDK/
+.. _SimpleLink Low Power F3 SDK v9.20.00.81 release notes: https://software-dl.ti.com/simplelink/esd/simplelink_lowpower_f3_sdk/9.20.00.81/exports/release_notes_simplelink_lowpower_f3_sdk_9_20_00_81.html
+.. _TI CCS Getting Started guide: https://software-dl.ti.com/ccs/esd/documents/users_guide/ccs_getting-started.html#creating-a-new-ccstudio-ide-project
+.. _UniFlash: https://www.ti.com/tool/UNIFLASH
+.. _TI SimpleLink CC27xx Getting Started guide: https://dev.ti.com/tirex/content/simplelink_lowpower_f3_sdk_9_20_00_81/docs/simplelink_mcu_sdk/html/quickstart-guide/quickstart-intro-cc23xx.html#build-your-first-program-for-the-device-device
+.. _Hubble Connect on the App Store: https://apps.apple.com/us/app/hubble-connect/id6751236191
+.. _Hubble Connect on Google Play: https://play.google.com/store/apps/details?id=com.hubble.connect


### PR DESCRIPTION
- Refactor sections that are common to all guides to its own directory so it can be shared.
- Add TI integration guide.

[Page Preview](https://hongnguyen635.github.io/hubble-device-sdk/integration_guides/ti/index.html)