### PR TITLE
samples: sat-cont & sat-dual-stack: Add board support for nrf54l15tag and XIAO ESP32-C6

### DIFF
--- a/port/zephyr/boards/nordic/nrf54/CMakeLists.txt
+++ b/port/zephyr/boards/nordic/nrf54/CMakeLists.txt
@@ -18,3 +18,7 @@ zephyr_link_libraries(libhubble_sat_nrf54)
 if(CONFIG_BOARD_NRF54L15DK)
 	zephyr_library_sources(nrf54l15dk.c)
 endif()
+
+if(CONFIG_BOARD_NRF54L15TAG)
+	zephyr_library_sources(nrf54l15tag.c)
+endif()

--- a/port/zephyr/boards/nordic/nrf54/nrf54l15tag.c
+++ b/port/zephyr/boards/nordic/nrf54/nrf54l15tag.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <zephyr/kernel.h>
+
+#include <hubble/sat.h>
+#include <hubble/sat/packet.h>
+#include <sat_soc.h>
+
+int hubble_sat_board_init(void)
+{
+	return 0;
+}
+
+int hubble_sat_board_enable(void)
+{
+	/* Set power, enable pa ... */
+	return hubble_sat_soc_enable();
+}
+
+int hubble_sat_board_disable(void)
+{
+	return hubble_sat_soc_disable();
+}
+
+int hubble_sat_board_packet_send(const struct hubble_sat_packet_frames *packet)
+{
+	return hubble_sat_soc_packet_send(packet);
+}

--- a/samples/esp-idf/sat-continuous/main/Kconfig.projbuild
+++ b/samples/esp-idf/sat-continuous/main/Kconfig.projbuild
@@ -11,4 +11,10 @@ menu "Sat Continuous Sample Configuration"
     help
         Hubble device's cryptographic key
 
+    config EXTERNAL_ANTENNA
+    bool "Select XIAO ESP32-C6 External Antenna"
+    default n
+    help
+        Select XIAO ESP32-C6 External Antenna - ufL
+
 endmenu

--- a/samples/esp-idf/sat-continuous/main/main.c
+++ b/samples/esp-idf/sat-continuous/main/main.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include "driver/gpio.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -22,6 +23,38 @@
 
 static const char *APP_TAG = "sat_continuous";
 static uint8_t _hubble_key[CONFIG_HUBBLE_KEY_SIZE];
+
+// Conditional external antenna selection
+static void select_external_antenna(void)
+{
+#ifdef CONFIG_EXTERNAL_ANTENNA
+    // GPIO3: RF switch power enable (active LOW)
+    gpio_config_t io_conf3 = {
+        .pin_bit_mask = (1ULL << GPIO_NUM_3),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE
+    };
+    ESP_ERROR_CHECK(gpio_config(&io_conf3));
+    ESP_ERROR_CHECK(gpio_set_level(GPIO_NUM_3, 0));  // LOW = power ON
+
+    // GPIO14: Antenna select (HIGH = external)
+    gpio_config_t io_conf14 = {
+        .pin_bit_mask = (1ULL << GPIO_NUM_14),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE
+    };
+    ESP_ERROR_CHECK(gpio_config(&io_conf14));
+    ESP_ERROR_CHECK(gpio_set_level(GPIO_NUM_14, 1));  // HIGH = external antenna
+
+    ESP_LOGI(APP_TAG, "External antenna selected (GPIO3=LOW, GPIO14=HIGH)");
+#else
+    ESP_LOGI(APP_TAG, "Using default (onboard) antenna");
+#endif
+}
 
 void app_main(void)
 {
@@ -45,6 +78,8 @@ void app_main(void)
 		ESP_LOG_BUFFER_HEX_LEVEL(APP_TAG, _hubble_key, outlen,
 					 ESP_LOG_DEBUG);
 	}
+	// Select external antenna
+	select_external_antenna();
 
 	err = hubble_init(0, _hubble_key);
 	if (err != 0) {

--- a/samples/esp-idf/sat-dual-stack/main/Kconfig.projbuild
+++ b/samples/esp-idf/sat-dual-stack/main/Kconfig.projbuild
@@ -19,4 +19,10 @@ menu "Sat Dual Stack Sample Configuration"
         This will set the sat timer for 2 minutes instead
         of until a satellite pass is overhead.
 
+    config EXTERNAL_ANTENNA
+    bool "Select XIAO ESP32-C6 External Antenna"
+    default n
+    help
+        Select XIAO ESP32-C6 External Antenna - ufL
+
 endmenu

--- a/samples/esp-idf/sat-dual-stack/main/main.c
+++ b/samples/esp-idf/sat-dual-stack/main/main.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include "driver/gpio.h"
 
 /* FreeRTOS */
 #include "freertos/FreeRTOS.h"
@@ -49,6 +50,38 @@ static esp_timer_handle_t _sat_timer;
 static void _sat_timer_cb(void *arg)
 {
 	xSemaphoreGive(_sat_tx_sem);
+}
+
+// Conditional external antenna selection
+static void select_external_antenna(void)
+{
+#ifdef CONFIG_EXTERNAL_ANTENNA
+    // GPIO3: RF switch power enable (active LOW)
+    gpio_config_t io_conf3 = {
+        .pin_bit_mask = (1ULL << GPIO_NUM_3),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE
+    };
+    ESP_ERROR_CHECK(gpio_config(&io_conf3));
+    ESP_ERROR_CHECK(gpio_set_level(GPIO_NUM_3, 0));  // LOW = power ON
+
+    // GPIO14: Antenna select (HIGH = external)
+    gpio_config_t io_conf14 = {
+        .pin_bit_mask = (1ULL << GPIO_NUM_14),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE
+    };
+    ESP_ERROR_CHECK(gpio_config(&io_conf14));
+    ESP_ERROR_CHECK(gpio_set_level(GPIO_NUM_14, 1));  // HIGH = external antenna
+
+    ESP_LOGI(APP_TAG, "External antenna selected (GPIO3=LOW, GPIO14=HIGH)");
+#else
+    ESP_LOGI(APP_TAG, "Using default (onboard) antenna");
+#endif
 }
 
 /*
@@ -114,6 +147,9 @@ void app_main(void)
 		ESP_LOGE(APP_TAG, "Failed to create semaphores");
 		return;
 	}
+
+	// Select external antenna
+	select_external_antenna();
 
 	/* Init and enable BLE */
 	ret = ble_init();

--- a/samples/zephyr/sat-continuous/boards/nrf54l15tag_nrf54l15_cpuapp.conf
+++ b/samples/zephyr/sat-continuous/boards/nrf54l15tag_nrf54l15_cpuapp.conf
@@ -1,0 +1,6 @@
+# --- Maximum TX Power ---
+# nRF54L15 supports up to +8 dBm (CSP package) or +7 dBm (QFN package).
+# The nRF54L15 Tag uses the CSP variant → maximum is +8 dBm.
+#
+# This sets the default TX power for advertising and connections.
+CONFIG_BT_CTLR_TX_PWR_PLUS_7=y

--- a/samples/zephyr/sat-continuous/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
+++ b/samples/zephyr/sat-continuous/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
@@ -1,0 +1,27 @@
+/*
+ * nRF54L15 Tag overlay
+ *
+ * - Enables the on-board SKY13348 RF switch
+ * - Selects Antenna 1 by default at boot (via GPIO hog)
+ */
+
+&sky13348 {
+    status = "okay";
+};
+
+/* Default to ANT1 at boot */
+&gpio1 {
+    ant1_hog: ant1_hog {
+        gpio-hog;
+        gpios = <9 GPIO_ACTIVE_HIGH>;   /* ANT1 */
+        output-high;
+        line-name = "rf-switch-v1";
+    };
+
+    ant2_hog: ant2_hog {
+        gpio-hog;
+        gpios = <10 GPIO_ACTIVE_LOW>;   /* ANT2 */
+        output-low;
+        line-name = "rf-switch-v2";
+    };
+};

--- a/samples/zephyr/sat-dual-stack/boards/nrf54l15tag_nrf54l15_cpuapp.conf
+++ b/samples/zephyr/sat-dual-stack/boards/nrf54l15tag_nrf54l15_cpuapp.conf
@@ -1,0 +1,6 @@
+# --- Maximum TX Power ---
+# nRF54L15 supports up to +8 dBm (CSP package) or +7 dBm (QFN package).
+# The nRF54L15 Tag uses the CSP variant → maximum is +8 dBm.
+#
+# This sets the default TX power for advertising and connections.
+CONFIG_BT_CTLR_TX_PWR_PLUS_7=y

--- a/samples/zephyr/sat-dual-stack/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
+++ b/samples/zephyr/sat-dual-stack/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
@@ -1,0 +1,27 @@
+/*
+ * nRF54L15 Tag overlay
+ *
+ * - Enables the on-board SKY13348 RF switch
+ * - Selects Antenna 1 by default at boot (via GPIO hog)
+ */
+
+&sky13348 {
+    status = "okay";
+};
+
+/* Default to ANT1 at boot */
+&gpio1 {
+    ant1_hog: ant1_hog {
+        gpio-hog;
+        gpios = <9 GPIO_ACTIVE_HIGH>;   /* ANT1 */
+        output-high;
+        line-name = "rf-switch-v1";
+    };
+
+    ant2_hog: ant2_hog {
+        gpio-hog;
+        gpios = <10 GPIO_ACTIVE_LOW>;   /* ANT2 */
+        output-low;
+        line-name = "rf-switch-v2";
+    };
+};


### PR DESCRIPTION
Overlay for nrf54l15tag selects antenna 1 by default but can be switched to antenna 2 or both in the overlay, while the config sets the tx power to the max (+7dbm). The XIAO board has an smd antenna it uses by default, so a kconfig.projbuild boolean `EXTERNAL_ANTENNA` and accompanying code snippet were added to select the external antenna (u.fL) using the on-board RF switch.