### PR TITLE
fix: docs: fix tab background color become invisible

### DIFF
--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -377,7 +377,7 @@ code,
 .ui.tabular.menu .active.item,
 .ui.segment,
 .sphinx-tabs-panel {
-    background-color: var(--code-background-color) !important;
+    background-color: var(--tabs-panel-background-color) !important;
 }
 
 .sphinx-tabs-tab {
@@ -385,8 +385,8 @@ code,
 }
 
 .sphinx-tabs-tab[aria-selected="true"] {
-    background-color: var(--code-background-color) !important;
-    border-bottom: 1px solid var(--code-background-color) !important;
+    background-color: var(--tabs-panel-background-color) !important;
+    border-bottom: 1px solid var(--tabs-panel-background-color) !important;
 }
 
 .sphinx-tabs .closeable {
@@ -407,6 +407,18 @@ code,
     border: none !important;
     border-top: 1px solid rgba(120, 115, 115, 0.14) !important;
     border-radius: 0 0 var(--default-radius) var(--default-radius) !important;
+}
+
+/*
+ * Code blocks keep their usual styling inside a tab, but a theme may need to
+ * override the background so it does not match the panel fill.
+ */
+.sphinx-tabs-panel .highlight {
+    background-color: var(--tabs-code-background-color, var(--highlight-background-color));
+}
+
+.sphinx-tabs-panel .highlight pre {
+    border-color: var(--tabs-code-background-color, var(--highlight-border-color));
 }
 /* Code literals */
 a.internal code.literal {

--- a/docs/static/css/dark.css
+++ b/docs/static/css/dark.css
@@ -124,6 +124,12 @@
     --tabs-hover: var(--deep-space-blue);
     --tabs-color: rgba(255, 255, 255, 0.7);
     --tabs-divider: rgba(120, 115, 115, 0.14);
+    --tabs-panel-background-color: var(--eclipse-blue);
+    /*
+     * The panel fill is also the code block background in this theme, so shift
+     * code blocks inside a tab one shade darker to keep them visible.
+     */
+    --tabs-code-background-color: var(--deep-space-blue);
 
     --grid-icons-color: var(--orion-mist);
     --grid-icons-bg-color: transparent;

--- a/docs/static/css/light.css
+++ b/docs/static/css/light.css
@@ -117,9 +117,16 @@
     --btn-neutral-background-color: var(--link-blue);
     --btn-neutral-hover-background-color: var(--hubble-blue);
     --footer-color: var(--gravity-grey);
-    --tabs-hover: var(--deep-space-blue);
-    --tabs-color: rgba(255, 255, 255, 0.7);
+    /* Dark text, so hover matches the background instead of inverting it */
+    --tabs-hover: var(--off-white);
+    --tabs-color: rgba(0, 0, 0, 0.7);
     --tabs-divider: rgba(120, 115, 115, 0.14);
+    /*
+     * From Hubble Brand Guidelines v1.0 Blue 050: a tint off the page,
+     * so the panel and the selected tab is visible instead of blending
+     * into the background.
+     */
+    --tabs-panel-background-color: #EFEFFB;
 
     --grid-icons-color: var(--link-blue);
     --grid-icons-bg-color: transparent;


### PR DESCRIPTION
2 fixes to the tab group, new colors aligning with the Hubble brand guidelines v1.0:

- In dark mode, background color of a tab panel is the same as the block background.

Before:
<img width="450" alt="Screenshot 2026-07-27 at 8 43 40 AM" src="https://github.com/user-attachments/assets/ca531392-c55d-4406-9551-1267dd4ee023" />

After:
<img width="450" alt="Screenshot 2026-07-27 at 8 44 06 AM" src="https://github.com/user-attachments/assets/7e9ddad3-7dc7-4741-8c43-e53ee8d69b0d" />

- In light mode, the background color of a tab is invisible unless hovering over it.

Before:
<img width="450" alt="Screenshot 2026-07-27 at 8 44 29 AM" src="https://github.com/user-attachments/assets/0f4d81e5-9705-4f7f-9257-e3254628f031" />

After:
<img width="450" alt="Screenshot 2026-07-27 at 8 44 57 AM" src="https://github.com/user-attachments/assets/00eba35d-dd1c-46ef-aad3-6234f95b0cc1" />