### PR TITLE
hdcv: Add hubble device configuration vector

### DIFF
--- a/include/hubble/hubble.h
+++ b/include/hubble/hubble.h
@@ -7,6 +7,7 @@
 #ifndef INCLUDE_HUBBLE_HUBBLE_H
 #define INCLUDE_HUBBLE_HUBBLE_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef CONFIG_HUBBLE_SAT_NETWORK
@@ -126,6 +127,36 @@ int hubble_key_set(const void *key);
  * @return 0 on success, negative error code on failure (Unix time mode only, if time not set)
  */
 int hubble_counter_get(uint32_t *counter);
+
+/**
+ * @brief Get the Hubble Device Configuration Vector (HDCV) for this build.
+ *
+ * Returns a compact, fixed-format string that describes the crypto,
+ * EID-rotation and network configuration compiled into the SDK, for example
+ * `HDCV:1.0/E:256/CS:UT/RP:S86400/N:T/TV:1`. The string is derived entirely
+ * from build-time options, so it can be logged, stored, or reported to identify
+ * how a device is configured.
+ *
+ * @return Pointer to a static, NUL-terminated HDCV string. Never NULL.
+ */
+const char *hubble_config_vector_get(void);
+
+/**
+ * @brief Check whether a Hubble Device Configuration Vector (HDCV) string
+ * matches this build's configuration.
+ *
+ * Compares @p hdcv against the Hubble Device Configuration Vector for this
+ * build (the string returned by @ref hubble_config_vector_get). Use it to
+ * confirm that a device is configured as expected — for example, that the
+ * vector a provisioning tool or the Cloud recorded still matches the firmware.
+ *
+ * @param hdcv NUL-terminated HDCV string to check.
+ *
+ * @return
+ *          - true if @p hdcv is non-NULL and equals this build's HDCV string.
+ *          - false otherwise (including when @p hdcv is NULL).
+ */
+bool hubble_config_vector_check(const char *hdcv);
 
 /**
  * @}

--- a/src/hubble.c
+++ b/src/hubble.c
@@ -6,8 +6,10 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "hubble_priv.h"
+#include "utils/hdcv.h"
 
 #include <hubble/hubble.h>
 
@@ -96,7 +98,8 @@ int hubble_init(uint64_t initial_time, const void *key)
 	}
 #endif /* CONFIG_HUBBLE_SAT_NETWORK */
 
-	HUBBLE_LOG_INFO("Hubble Device SDK initialized\n");
+	HUBBLE_LOG_INFO("Hubble Device SDK initialized (%s)\n",
+			HUBBLE_DEVICE_CONFIG_VECTOR);
 
 	return 0;
 }
@@ -136,4 +139,18 @@ int hubble_counter_get(uint32_t *counter)
 #endif
 
 	return 0;
+}
+
+const char *hubble_config_vector_get(void)
+{
+	return HUBBLE_DEVICE_CONFIG_VECTOR;
+}
+
+bool hubble_config_vector_check(const char *hdcv)
+{
+	if (hdcv == NULL) {
+		return false;
+	}
+
+	return strcmp(HUBBLE_DEVICE_CONFIG_VECTOR, hdcv) == 0;
 }

--- a/src/utils/hdcv.h
+++ b/src/utils/hdcv.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SRC_UTILS_HDCV_H
+#define SRC_UTILS_HDCV_H
+
+#include "macros.h"
+
+/*
+ * Hubble Device Configuration Vector (HDCV) — a compact, fixed-format string
+ * describing this build's crypto, EID-rotation and network configuration.
+ * It is derived entirely from build options so the device can report or log
+ * its configuration.
+ *
+ *     HDCV:<version>/E:<enc>[/CS:<src>][/EC:<count>][/RP:<period>][/N:<net>][/TV:<ver>][/SV:<ver>]
+ */
+
+/* E — encryption / key size */
+#if defined(CONFIG_HUBBLE_NETWORK_KEY_256)
+#define HDCV_E "/E:256"
+#elif defined(CONFIG_HUBBLE_NETWORK_KEY_128)
+#define HDCV_E "/E:128"
+#else
+#define HDCV_E ""
+#endif
+
+/* CS — counter source  */
+#if defined(CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME)
+#define HDCV_CS "/CS:DU"
+#elif defined(CONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME)
+#define HDCV_CS "/CS:UT"
+#else
+#define HDCV_CS ""
+#endif
+
+/* EC — EID count; only meaningful for device uptime, fixed at 128 today */
+#if defined(CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME)
+#define HDCV_EC "/EC:128"
+#else
+#define HDCV_EC ""
+#endif
+
+/* RP — rotation period in seconds */
+#if defined(CONFIG_HUBBLE_EID_ROTATION_PERIOD_SEC)
+#define HDCV_RP "/RP:S" HUBBLE_STRINGIFY(CONFIG_HUBBLE_EID_ROTATION_PERIOD_SEC)
+#else
+#define HDCV_RP ""
+#endif
+
+/* N — network */
+#if defined(CONFIG_HUBBLE_BLE_NETWORK) && defined(CONFIG_HUBBLE_SAT_NETWORK)
+#define HDCV_N "/N:TS"
+#elif defined(CONFIG_HUBBLE_BLE_NETWORK)
+#define HDCV_N "/N:T"
+#elif defined(CONFIG_HUBBLE_SAT_NETWORK)
+#define HDCV_N "/N:S"
+#else
+#define HDCV_N ""
+#endif
+
+/* TV — terrestrial protocol version (present with terrestrial network) */
+#if defined(CONFIG_HUBBLE_BLE_NETWORK)
+#define HDCV_TV "/TV:0"
+#else
+#define HDCV_TV ""
+#endif
+
+/* SV — protocol version (present with satellite network) */
+#if defined(CONFIG_HUBBLE_SAT_NETWORK_PROTOCOL_V1)
+#define HDCV_SV "/SV:0"
+#else
+#define HDCV_SV ""
+#endif
+
+#define HUBBLE_DEVICE_CONFIG_VECTOR                                            \
+	"HDCV:1.0" HDCV_E HDCV_CS HDCV_EC HDCV_RP HDCV_N HDCV_TV HDCV_SV
+
+#endif /* SRC_UTILS_HDCV_H */

--- a/src/utils/hdcv.h
+++ b/src/utils/hdcv.h
@@ -15,7 +15,7 @@
  * It is derived entirely from build options so the device can report or log
  * its configuration.
  *
- *     HDCV:<version>/E:<enc>[/CS:<src>][/EC:<count>][/RP:<period>][/N:<net>][/TV:<ver>][/SV:<ver>]
+ * HDCV:<version>/E:<enc>[/CS:<src>][/EC:<count>][/RP:<period>][/N:<net>][/TV:<ver>][/SV:<ver>]
  */
 
 /* E — encryption / key size */

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -10,8 +10,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define HUBBLE_ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+#define HUBBLE_STRINGIFY2(x)     #x
+#define HUBBLE_STRINGIFY(x)      HUBBLE_STRINGIFY2(x)
 
+#define HUBBLE_ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define HUBBLE_CPU_TO_BE32(val)                                                \

--- a/tests/zephyr/hubble-api/src/main.c
+++ b/tests/zephyr/hubble-api/src/main.c
@@ -9,6 +9,7 @@
 #include <zephyr/ztest.h>
 
 #include <stdint.h>
+#include <string.h>
 
 static uint64_t _unix_time = 1760210751803ULL;
 static uint8_t _key[CONFIG_HUBBLE_KEY_SIZE];
@@ -199,6 +200,64 @@ ZTEST(hubble_api_test, test_counter_get)
 	/* Device uptime counter wraps at HUBBLE_EID_POOL_SIZE (128) */
 	zassert_true(counter < 128U);
 #endif
+}
+
+ZTEST(hubble_api_test, test_config_vector_get)
+{
+	const char *hdcv = hubble_config_vector_get();
+
+	/* Must return a non-NULL, versioned HDCV string. */
+	zassert_not_null(hdcv);
+	zassert_true(strncmp(hdcv, "HDCV:1.0/", strlen("HDCV:1.0/")) == 0,
+		     "unexpected HDCV prefix: %s", hdcv);
+}
+
+ZTEST(hubble_api_test, test_config_vector_check_self)
+{
+	/* The build's own vector must be recognized as matching. */
+	zassert_true(hubble_config_vector_check(hubble_config_vector_get()));
+}
+
+ZTEST(hubble_api_test, test_config_vector_check_null)
+{
+	/* NULL is never a match. */
+	zassert_false(hubble_config_vector_check(NULL));
+}
+
+ZTEST(hubble_api_test, test_config_vector_check_mismatch)
+{
+	/* An empty string does not match. */
+	zassert_false(hubble_config_vector_check(""));
+
+	/* Garbage does not match. */
+	zassert_false(hubble_config_vector_check("not-an-hdcv"));
+
+	/*
+	 * A well-formed but different vector must not match.  This build is
+	 * satellite-only (N:S), so a terrestrial vector can never equal it.
+	 */
+	zassert_false(hubble_config_vector_check(
+		"HDCV:1.0/E:128/CS:UT/RP:S1/N:T/TV:0"));
+}
+
+ZTEST(hubble_api_test, test_config_vector_check_is_exact)
+{
+	const char *hdcv = hubble_config_vector_get();
+	size_t len = strlen(hdcv);
+	char buf[64];
+
+	zassert_true(len + sizeof("/X:1") <= sizeof(buf),
+		     "HDCV string too long for test buffer");
+
+	/* A truncated prefix of the real vector must not match. */
+	memcpy(buf, hdcv, len + 1);
+	buf[len - 1] = '\0';
+	zassert_false(hubble_config_vector_check(buf));
+
+	/* The real vector with an extra trailing field must not match. */
+	memcpy(buf, hdcv, len + 1);
+	strcat(buf, "/X:1");
+	zassert_false(hubble_config_vector_check(buf));
 }
 
 static void *hubble_api_test_setup(void)


### PR DESCRIPTION
Add a single string (vector) representing all options set in a build. This can be used by an application to check if the fw configuration matches with the provisioned configuration.