### PR TITLE
docs: reorganize and consolidate SDK documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,7 +65,7 @@ Additional Resources
 	   <p>Service modules, port layer, code organization &amp; conventions</p>
        </li>
        <li class="grid-item">
-	   <a href="ble/index.html">
+	   <a href="terrestrial/index.html">
                <span class="grid-icon fa fa-bluetooth-b"></span>
 	       <h2>Terrestrial Network</h2>
 	   </a>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,11 +86,11 @@ Additional Resources
 
    introduction/index
    architecture/index
+   terrestrial/index
+   satellite/index
    quickstart/index
    integration_guides/index
    best-practices/index
-   terrestrial/index
-   satellite/index
    security/index
    releases/index
 

--- a/docs/integration_guides/index.rst
+++ b/docs/integration_guides/index.rst
@@ -3,6 +3,18 @@
 Integration Guides
 ##################
 
+End-to-end guides for building a complete **satellite dual-stack** application
+(Satellite + BLE) on a specific vendor platform. Each guide covers obtaining
+ephemeris data, using pass prediction to schedule transmissions, beaconing over
+BLE while waiting for a pass, transmitting during the pass window, and verifying
+the result on hardware.
+
+These guides assume the SDK already builds on your platform. If you have not set
+that up yet, start with :ref:`hubble_quickstart`, which covers pulling in the
+SDK and running a first sample. For the concepts behind the workflow — pass
+prediction, reliability modes, and clock drift — see the
+:ref:`hubble_satellite_introduction`.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -1,8 +1,21 @@
 .. _hubble_quickstart:
 
-Quick Start
-###########
+Platform Setup
+##############
 
+These guides cover **getting the Hubble Device SDK into your build system** and
+running a first sample application on each supported platform. Pick the guide
+that matches your environment.
+
+Each guide shows how to pull in the SDK, enable the BLE (Terrestrial) and/or
+Satellite Network modules, and build and flash a sample.
+
+.. note::
+
+   Platform Setup is the starting point. Once the SDK builds on your platform,
+   the :ref:`hubble_integration_guides` walk through building a complete
+   satellite dual-stack application end to end (pass prediction, BLE
+   provisioning, RF verification) on supported vendor hardware.
 
 .. toctree::
    :maxdepth: 1
@@ -13,5 +26,3 @@ Quick Start
    ti/index
    esp-idf/index
    bare-metal/index
-
-

--- a/docs/quickstart/ti/index.rst
+++ b/docs/quickstart/ti/index.rst
@@ -18,6 +18,13 @@ can be configured alongside the TI SDK drivers in the same script.
    :ref:`freertos_quick_start` instead — it describes how to include the SDK
    sources and flags directly via the provided Makefile fragment.
 
+.. seealso::
+
+   This page covers TI SDK setup and SysConfig integration. For a complete,
+   end-to-end **satellite dual-stack** application on TI hardware — pass
+   prediction, BLE beaconing, and RF verification — see the
+   :ref:`ti_integration_guide`.
+
 Prerequisites
 *************
 

--- a/docs/quickstart/zephyr/index.rst
+++ b/docs/quickstart/zephyr/index.rst
@@ -138,6 +138,12 @@ the upstream Zephyr steps above, with the differences below.
 
 .. note::
 
+   This covers NCS workspace setup only. For a complete satellite dual-stack
+   application on Nordic hardware — board bring-up, pass prediction, BLE
+   provisioning, and verification — see the :ref:`ncs_integration_guide`.
+
+.. note::
+
    Adding Hubble Network as a *module* to an existing NCS application is
    identical to the `Adding Hubble Network to Zephyr`_ step, only the
    manifest and toolchain differ.

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -191,8 +191,8 @@ Support Policy
 The Hubble Device SDK maintains different support levels depending on release
 type:
 
-Stable  Releases
-================
+Stable Releases
+===============
 
 The current and previous releases receive:
 

--- a/docs/satellite/clock-drift.rst
+++ b/docs/satellite/clock-drift.rst
@@ -1,0 +1,120 @@
+.. _hubble_satellite_clock_drift:
+
+Clock Drift Compensation
+########################
+
+For reliability modes with retries, the SDK may add extra transmissions to
+account for estimated clock drift since the last time synchronization. The drift
+estimate is based on ``CONFIG_HUBBLE_SAT_NETWORK_DEVICE_TDR`` in parts per
+million (PPM).
+
+The SDK computes the elapsed time since the last time sync, estimates drift, and
+adds one retry for each full retransmission interval of drift. This widens the
+effective transmission coverage when the device clock may be early or late.
+
+Pass prediction also accounts for drift by starting the calculated transmission
+window earlier. Keep Unix time synchronized when possible to reduce unnecessary
+extra retries.
+
+Understanding PPM
+*****************
+
+PPM (parts per million) is the maximum frequency deviation of an oscillator from
+its nominal frequency. A clock rated at 50 PPM can drift at most 50 microseconds
+per second, which accumulates to:
+
+* 50 ms per 1,000 seconds (~17 minutes)
+* 180 ms per hour
+* 4.3 seconds per day
+
+The SDK uses ``CONFIG_HUBBLE_SAT_NETWORK_DEVICE_TDR`` to estimate the total
+accumulated drift since the last time synchronization:
+
+.. code-block:: none
+
+   drift_ms = (elapsed_since_last_sync_ms × TDR_ppm) / 1,000,000
+
+One additional retry is then added for each full retransmission interval covered
+by that drift. For example, with ``HUBBLE_SAT_RELIABILITY_NORMAL`` (20-second
+interval) and a 100 PPM clock that has not synced for 3 hours:
+
+.. code-block:: none
+
+   drift_ms           = 10,800,000 ms × 100 / 1,000,000 = 1,080 ms
+   additional_retries = 1,080 ms / 20,000 ms            = 0
+
+At 30 hours without a sync:
+
+.. code-block:: none
+
+   drift_ms           = 108,000,000 ms × 100 / 1,000,000 = 10,800 ms
+   additional_retries = 10,800 ms / 20,000 ms            = 0  (rounds down)
+
+At 56 hours without a sync:
+
+.. code-block:: none
+
+   drift_ms           = 201,600,000 ms × 100 / 1,000,000 = 20,160 ms
+   additional_retries = 20,160 ms / 20,000 ms            = 1
+
+For most devices syncing time at least once per day, drift compensation adds
+zero or one extra retries. Higher-PPM oscillators or longer sync gaps produce
+more extra retries.
+
+Maximum Additional Retries
+==========================
+
+Two caps bound the total number of retries:
+
+* The drift estimate is capped at **90 minutes** regardless of how long the
+  device has gone without a time sync.
+* The total retry count (baseline + additional) is capped to 90 min / retry interval.
+
+In practice these ceilings are only reached by high-PPM oscillators that have
+not synchronized time for many days. At 100 PPM, reaching 90 minutes of
+accumulated drift requires roughly 625 days without a sync.
+
+Finding the TDR for Your Hardware
+*********************************
+
+The Time Drift Rate (TDR) value to configure comes directly from the oscillator
+used as the device clock source. The typical lookup path is:
+
+1. **Identify the clock source.** Check the board schematic or SoC reference
+   manual to find which oscillator drives the timekeeping peripheral (RTC or
+   low-frequency oscillator). It is usually a 32.768 kHz crystal or, for
+   lower-cost designs, an internal RC oscillator.
+
+2. **Read the datasheet.** Open the crystal or oscillator datasheet and look
+   for the **frequency accuracy** or **frequency tolerance** specification,
+   typically in a table labelled *Electrical Characteristics* or *AC
+   Characteristics*. The value is expressed as ±X ppm over a stated temperature
+   and supply-voltage range.
+
+3. **Use the worst-case figure.** Datasheets often list both an initial
+   tolerance at room temperature and a wider tolerance over the full operating
+   temperature range. Use the larger value.
+
+Typical ranges by oscillator type:
+
+.. list-table::
+   :widths: 40 20 40
+   :header-rows: 1
+
+   * - Oscillator type
+     - Typical PPM
+     - Notes
+   * - TCXO (temperature-compensated crystal)
+     - 0.5 – 5
+     - Best accuracy; used in communication-grade designs
+   * - External crystal (XTAL)
+     - 10 – 100
+     - Most common; check datasheet for your specific part
+   * - Internal RC oscillator
+     - 200 – 5,000
+     - Factory calibration at room temperature only; degrades with temperature
+
+If you cannot obtain the exact figure, use a conservative (higher) estimate.
+Underestimating PPM causes the device to transmit fewer extra retries than
+needed, which reduces delivery probability when the clock has drifted
+significantly.

--- a/docs/satellite/index.rst
+++ b/docs/satellite/index.rst
@@ -100,9 +100,10 @@ recommended workflow for battery-powered devices.
 
 .. seealso::
 
-   For guidance on selecting pass options — choosing the minimum elevation
-   angle, interpreting the pass result, and computing multiple upcoming passes —
-   see :ref:`hubble_pass_prediction_best_practices`.
+   :ref:`hubble_pass_prediction_best_practices` is the complete guide to pass
+   prediction: choosing the minimum elevation angle, reading the pass result,
+   and computing multiple upcoming passes. This section covers only the inputs
+   the SDK needs and how to obtain them.
 
 .. warning::
 
@@ -205,40 +206,14 @@ Hard-coded parameters are simple and work well for fixed firmware images or
 devices without a provisioning channel. Refresh and rebuild the generated file
 when the orbital data used by your product needs to be updated.
 
-Computing the Next Pass
-=======================
+Computing a Pass
+================
 
-After the SDK has time, location, and orbital data, use
-:c:func:`hubble_sat_next_pass_get` to find the next pass for one location:
-
-.. code-block:: c
-
-   struct hubble_sat_device_pos pos = {
-           .lat = 47.0,
-           .lon = -122.0,
-   };
-   struct hubble_sat_pass_info pass;
-   uint64_t now_ms = hubble_time_get();
-
-   err = hubble_sat_next_pass_get(now_ms, &pos, &pass);
-   if (err != 0) {
-           /* No pass found or invalid input. */
-   }
-
-``pass.start`` is the recommended time to begin the satellite transmission
-sequence. ``pass.culmination`` is the time of maximum pass alignment.
-``pass.duration`` is the expected transmission window duration in milliseconds.
-``pass.max_elevation_angle`` reports the maximum elevation angle for the pass.
-
-If a pass is already in progress, compute the next one by starting the search
-after the current pass window:
-
-.. code-block:: c
-
-   if (pass.start <= now_ms) {
-           err = hubble_sat_next_pass_get(pass.start + pass.duration,
-                                          &pos, &pass);
-   }
+Once time, location, and orbital data are available, use
+:c:func:`hubble_sat_next_pass_get` to find the next pass and schedule the
+transmission against ``pass.start``. Reading the result, selecting a minimum
+elevation angle, and looking several passes into the future are all covered in
+:ref:`hubble_pass_prediction_best_practices`.
 
 Common API Workflow
 *******************
@@ -347,157 +322,11 @@ Typical workflow:
 
 This workflow is appropriate for devices that already use BLE for local
 connectivity, provisioning, or nearby network operation and only need satellite
-transmission during predicted windows.
-
-Transmission Logic
-******************
-
-The reliability mode controls how many times the SDK asks the platform radio
-port to send the same packet and how far apart those transmissions are spaced.
-
-.. list-table:: Satellite Reliability Modes
-   :widths: 30 20 20 30
-   :header-rows: 1
-
-   * - Mode
-     - Baseline transmissions
-     - Interval
-     - Intended use
-   * - ``HUBBLE_SAT_RELIABILITY_NONE``
-     - 1
-     - 0 seconds
-     - Testing or externally managed retries
-   * - ``HUBBLE_SAT_RELIABILITY_NORMAL``
-     - 8
-     - 20 seconds
-     - Default balance of reliability and power
-   * - ``HUBBLE_SAT_RELIABILITY_HIGH``
-     - 16
-     - 10 seconds
-     - Higher reliability with higher energy cost
-
-.. _hubble_satellite_clock_drift:
-
-Clock Drift Compensation
-========================
-
-For modes with retries, the SDK may add extra transmissions to account for
-estimated clock drift since the last time synchronization. The drift estimate is
-based on ``CONFIG_HUBBLE_SAT_NETWORK_DEVICE_TDR`` in parts per million (PPM).
-
-The SDK computes the elapsed time since the last time sync, estimates drift, and
-adds one retry for each full retransmission interval of drift. This widens the
-effective transmission coverage when the device clock may be early or late.
-
-Pass prediction also accounts for drift by starting the calculated transmission
-window earlier. Keep Unix time synchronized when possible to reduce unnecessary
-extra retries.
-
-Understanding PPM
------------------
-
-PPM (parts per million) is the maximum frequency deviation of an oscillator from
-its nominal frequency. A clock rated at 50 PPM can drift at most 50 microseconds
-per second, which accumulates to:
-
-* 50 ms per 1,000 seconds (~17 minutes)
-* 180 ms per hour
-* 4.3 seconds per day
-
-The SDK uses ``CONFIG_HUBBLE_SAT_NETWORK_DEVICE_TDR`` to estimate the total
-accumulated drift since the last time synchronization:
-
-.. code-block:: none
-
-   drift_ms = (elapsed_since_last_sync_ms × TDR_ppm) / 1,000,000
-
-One additional retry is then added for each full retransmission interval covered
-by that drift. For example, with ``HUBBLE_SAT_RELIABILITY_NORMAL`` (20-second
-interval) and a 100 PPM clock that has not synced for 3 hours:
-
-.. code-block:: none
-
-   drift_ms          = 10,800,000 ms × 100 / 1,000,000 = 1,080 ms
-   additional_retries = 1,080 ms / 20,000 ms            = 0
-
-At 30 hours without a sync:
-
-.. code-block:: none
-
-   drift_ms          = 108,000,000 ms × 100 / 1,000,000 = 10,800 ms
-   additional_retries = 10,800 ms / 20,000 ms            = 0  (rounds down)
-
-At 56 hours without a sync:
-
-.. code-block:: none
-
-   drift_ms          = 201,600,000 ms × 100 / 1,000,000 = 20,160 ms
-   additional_retries = 20,160 ms / 20,000 ms            = 1
-
-For most devices syncing time at least once per day, drift compensation adds
-zero or one extra retries. Higher-PPM oscillators or longer sync gaps produce
-more extra retries.
-
-Maximum Additional Retries
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Two caps bound the total number of retries:
-
-* The drift estimate is capped at **90 minutes** regardless of how long the
-  device has gone without a time sync.
-* The total retry count (baseline + additional) is capped to 90 min / retry interval.
-
-In practice these ceilings are only reached by high-PPM oscillators that have
-not synchronized time for many days. At 100 PPM, reaching 90 minutes of
-accumulated drift requires roughly 625 days without a sync.
-
-Finding the TDR for Your Hardware
-----------------------------------
-
-The Time Drift Rate (TDR) value to configure comes directly from the oscillator
-used as the device clock source. The typical lookup path is:
-
-1. **Identify the clock source.** Check the board schematic or SoC reference
-   manual to find which oscillator drives the timekeeping peripheral (RTC or
-   low-frequency oscillator). It is usually a 32.768 kHz crystal or, for
-   lower-cost designs, an internal RC oscillator.
-
-2. **Read the datasheet.** Open the crystal or oscillator datasheet and look
-   for the **frequency accuracy** or **frequency tolerance** specification,
-   typically in a table labelled *Electrical Characteristics* or *AC
-   Characteristics*. The value is expressed as ±X ppm over a stated temperature
-   and supply-voltage range.
-
-3. **Use the worst-case figure.** Datasheets often list both an initial
-   tolerance at room temperature and a wider tolerance over the full operating
-   temperature range. Use the larger value.
-
-Typical ranges by oscillator type:
-
-.. list-table::
-   :widths: 40 20 40
-   :header-rows: 1
-
-   * - Oscillator type
-     - Typical PPM
-     - Notes
-   * - TCXO (temperature-compensated crystal)
-     - 0.5 – 5
-     - Best accuracy; used in communication-grade designs
-   * - External crystal (XTAL)
-     - 10 – 100
-     - Most common; check datasheet for your specific part
-   * - Internal RC oscillator
-     - 200 – 5,000
-     - Factory calibration at room temperature only; degrades with temperature
-
-If you cannot obtain the exact figure, use a conservative (higher) estimate.
-Underestimating PPM causes the device to transmit fewer extra retries than
-needed, which reduces delivery probability when the clock has drifted
-significantly.
+transmission during predicted windows. For a complete, platform-specific
+walkthrough of this pattern, see the :ref:`hubble_integration_guides`.
 
 Radio Timing
-============
+************
 
 :c:func:`hubble_sat_packet_send` is synchronous. During the call, the platform
 port typically:
@@ -515,37 +344,23 @@ starting conflicting radio activity until it returns. Dual-stack applications
 should stop BLE before satellite transmission unless the platform explicitly
 supports concurrent operation.
 
+Reliability and Clock Drift
+***************************
+
+The reliability mode selects the number of retries and their spacing, trading
+delivery probability against energy use. For modes with retries, the SDK also
+adds transmissions to compensate for accumulated clock drift.
+
+* :ref:`hubble_satellite_reliability` — the reliability modes and how to choose
+  one for your power budget.
+* :ref:`hubble_satellite_clock_drift` — the drift model, the PPM math, and how
+  to find the ``CONFIG_HUBBLE_SAT_NETWORK_DEVICE_TDR`` value for your hardware.
+
 Supporting New Boards
 *********************
 
 See :ref:`board_support` for integration paths, required APIs, SoC-specific
 guidance, and the board support checklist.
-
-.. _hubble_satellite_reliability:
-
-Power Consumption and Reliability
-*********************************
-
-Satellite reliability and power consumption are directly related. More retries
-increase the chance that a satellite receives the packet, but they keep the
-radio active for longer and increase total energy use.
-
-Use these guidelines when selecting a mode:
-
-* Use ``HUBBLE_SAT_RELIABILITY_NONE`` only for testing, lab validation, or
-  applications that implement their own scheduling and retry policy.
-* Use ``HUBBLE_SAT_RELIABILITY_NORMAL`` as the default production setting.
-* Use ``HUBBLE_SAT_RELIABILITY_HIGH`` when delivery probability is more
-  important than energy consumption.
-* Use pass prediction to avoid transmitting when a satellite is unlikely to be
-  visible.
-* Keep time synchronized to minimize drift-compensation retries.
-* Avoid very short continuous-transmission intervals on battery-powered devices.
-
-For battery-powered products, the most power-efficient design is usually a
-pass-predicted workflow: sleep or use low-power BLE between passes, wake before
-``pass.start``, transmit with the lowest reliability mode that meets the product
-delivery requirement, then return to the low-power state.
 
 Configuration Notes
 *******************
@@ -564,10 +379,10 @@ Important related options include:
 See :ref:`hubble_configuration` for the complete configuration reference. The
 full satellite API is documented in the :ref:`hubble_sat_api` reference.
 
-Board Support
-*************
-
 .. toctree::
    :maxdepth: 1
+   :hidden:
 
+   reliability
+   clock-drift
    board-support

--- a/docs/satellite/reliability.rst
+++ b/docs/satellite/reliability.rst
@@ -1,0 +1,61 @@
+.. _hubble_satellite_reliability:
+
+Reliability and Power Consumption
+#################################
+
+The reliability mode passed to :c:func:`hubble_sat_packet_send` controls how
+many times the SDK asks the platform radio port to send the same packet and how
+far apart those transmissions are spaced. It is the primary trade-off between
+delivery probability and energy use.
+
+Reliability Modes
+*****************
+
+.. list-table:: Satellite Reliability Modes
+   :widths: 30 20 20 30
+   :header-rows: 1
+
+   * - Mode
+     - Baseline transmissions
+     - Interval
+     - Intended use
+   * - ``HUBBLE_SAT_RELIABILITY_NONE``
+     - 1
+     - 0 seconds
+     - Testing or externally managed retries
+   * - ``HUBBLE_SAT_RELIABILITY_NORMAL``
+     - 8
+     - 20 seconds
+     - Default balance of reliability and power
+   * - ``HUBBLE_SAT_RELIABILITY_HIGH``
+     - 16
+     - 10 seconds
+     - Higher reliability with higher energy cost
+
+For modes with retries, the SDK may add extra transmissions to compensate for
+estimated clock drift since the last time synchronization. See
+:ref:`hubble_satellite_clock_drift` for the drift model and how to configure it.
+
+Choosing a Mode
+***************
+
+Satellite reliability and power consumption are directly related. More retries
+increase the chance that a satellite receives the packet, but they keep the
+radio active for longer and increase total energy use.
+
+Use these guidelines when selecting a mode:
+
+* Use ``HUBBLE_SAT_RELIABILITY_NONE`` only for testing, lab validation, or
+  applications that implement their own scheduling and retry policy.
+* Use ``HUBBLE_SAT_RELIABILITY_NORMAL`` as the default production setting.
+* Use ``HUBBLE_SAT_RELIABILITY_HIGH`` when delivery probability is more
+  important than energy consumption.
+* Use pass prediction to avoid transmitting when a satellite is unlikely to be
+  visible.
+* Keep time synchronized to minimize drift-compensation retries.
+* Avoid very short continuous-transmission intervals on battery-powered devices.
+
+For battery-powered products, the most power-efficient design is usually a
+pass-predicted workflow: sleep or use low-power BLE between passes, wake before
+``pass.start``, transmit with the lowest reliability mode that meets the product
+delivery requirement, then return to the low-power state.

--- a/docs/terrestrial/index.rst
+++ b/docs/terrestrial/index.rst
@@ -11,7 +11,7 @@ The Hubble Terrestrial Network is the name Hubble uses for its network built on
 Bluetooth® Low Energy (BLE). It is a framework designed to provide secure and
 efficient communication within a Bluetooth Low Energy (BLE) environment.
 Advanced encryption techniques and Bluetooth technology protect data
-integrity and privacy across distributed systems. The Hubble Terrestrial API, definede
+integrity and privacy across distributed systems. The Hubble Terrestrial API, defined
 in the **hubble/ble.h** header file, provides a comprehensive set of functions
 for initializing, configuring, and managing network operations.
 


### PR DESCRIPTION
Reorganizes the documentation to fix a broken link, remove duplication in the
satellite content, and give readers a clear starting point. No content was lost —
material was moved into more discoverable locations and de-duplicated.


For reference: https://ceolin.github.io/hubble-device-sdk/index.html