### PR TITLE
docs: add a version selector dropdown

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -139,3 +139,30 @@ jobs:
           destination_dir: ${{ needs.build.outputs.slug }}
           keep_files: true
           commit_message: "Deploy docs for ${{ needs.build.outputs.slug }}"
+
+      # Check out gh-pages so we can update the versions file
+      - name: Check out gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Update Versions File
+        working-directory: gh-pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # get the list of branches, filter to main and release/*,
+          # and write to versions.json
+          gh api "repos/$GITHUB_REPOSITORY/branches" --paginate --jq '.[].name' \
+            | grep -E '^main$|^release/' \
+            | jq -R . | jq -s . > versions.json
+          git add versions.json
+          if git diff --cached --quiet; then
+            echo "versions.json unchanged - nothing to commit"
+          else
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "Update versions.json"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ docs/_doxygen/
 **/build/**
 .cache/
 .ruff_cache/
+**/__pycache__/
 
 # generated files
 **/key.c

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,7 @@ def _fix_breathe_toc_entries(app, doctree):
 def setup(app):
     # theme customizations
     app.add_css_file("css/custom.css")
+    app.add_js_file("js/version-selector.js")
     # Priority 499 < default 500 so our handler runs before TocTreeCollector.process_doc,
     # which builds sidebar entries from _toc_name/_toc_parts at priority 500.
     app.connect("doctree-read", _fix_breathe_toc_entries, priority=499)

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -858,6 +858,88 @@ a.icon.icon-home {
     opacity: 0.9;
 }
 
+/* Documentation version selector */
+.version-section {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.9rem 1.5rem;
+    background-color: var(--navbar-background-color);
+    border-top: 1px solid var(--navbar-side-divider);
+}
+
+/* label styled like the nav section captions (e.g. "REFERENCE") */
+.version-label {
+    color: var(--navbar-heading-color);
+    font-family: var(--header-font-family), sans-serif;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.75px;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.version-selector-wrapper {
+    position: relative;
+    flex: 0 0 auto;
+}
+
+.version-selector {
+    box-sizing: border-box;
+    /* compact; extra right padding leaves room for the drop-down arrow */
+    padding: 6px 26px 6px 12px;
+    border: 1px solid var(--search-input-border-color);
+    border-radius: var(--default-radius);
+    background-color: var(--input-background-color);
+    /* sidebar text color: stays light in both themes */
+    color: var(--navbar-color);
+    box-shadow: none;
+    font-size: 13px;
+    font-family: var(--system-font-family), monospace;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}
+
+.version-selector:hover,
+.version-selector:focus {
+    /* brand blue (--hubble-blue) accent, same as the search box active state */
+    border-color: var(--search-input-border-color-active);
+    outline: none;
+}
+
+/* dropdown option list (opaque sidebar background so it's readable) */
+.version-selector option {
+    background-color: var(--navbar-background-color);
+    color: var(--navbar-color);
+}
+
+/* custom drop-down, since appearance:none removes the native arrow */
+.version-selector-wrapper::after {
+    content: "";
+    position: absolute;
+    right: 11px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid var(--navbar-color);
+}
+
+/* pin the section to the bottom of the sidebar (desktop) */
+@media only screen and (min-width: 769px) {
+    .version-section {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 1;
+    }
+}
+
 /* First level of navigation items */
 
 .wy-menu-vertical a {
@@ -1048,7 +1130,12 @@ a.icon.icon-home {
 .wy-menu.wy-menu-vertical {
     overflow-y: auto;
     overflow-x: hidden;
-    max-height: calc(100% - 243px);
+    /*
+     * Keep the scrolling nav between the fixed top and bottom regions:
+     * subtract 243px reserved at the TOP (logo + search box) and
+     * 64px reserved at the BOTTOM (pinned version section).
+     */
+    max-height: calc(100% - 243px - 64px);
 }
 @media screen and (max-width: 768px) {
     .wy-nav-side {

--- a/docs/static/js/version-selector.js
+++ b/docs/static/js/version-selector.js
@@ -1,0 +1,107 @@
+// Populate a documentation version selector in the sidebar.
+//
+// Reads the list of published versions from versions.json at the docs root
+// (written by the CI deploy job) and renders a dropdown for switching
+// between versions.
+
+(function () {
+  "use strict";
+
+  // Set by init() once the DOM is ready. Kept in this scope so renderSelector
+  // can use them.
+  let basePath = "/";
+  let currentVersion = "";
+  let pageWithinVersion = "";
+
+  function init() {
+    // The docs root path.
+    // Injected by layout.html, because each page lives under <root>/<version>/
+    // and the script has no other reliable way to know where the root is.
+    const meta = document.querySelector('meta[name="docs-base-path"]');
+    basePath = meta ? meta.content : "/";
+
+    // Find out which version this is currently on
+    const rest = window.location.pathname.startsWith(basePath)
+      ? window.location.pathname.slice(basePath.length)
+      : "";
+    const segments = rest.split("/");
+    currentVersion = segments.shift() || "";
+    pageWithinVersion = segments.join("/");
+
+    // Fetch the version list
+    fetch(basePath + "versions.json")
+      .then((resp) => (resp.ok ? resp.json() : Promise.reject(resp.status)))
+      .then(renderSelector)
+      .catch(() => {
+        // No versions.json (e.g. a local build) -> no selector. Fail silently.
+      });
+  }
+
+  // Convert a branch name into its deployed folder slug,
+  // so "release/1.0-branch" -> "release-1.0-branch".
+  function slug(branch) {
+    return branch.replace(/\//g, "-");
+  }
+
+  // Turn a branch name into short display text for the dropdown.
+  // e.g. "release/1.0-branch" -> "1.0"
+  function label(branch) {
+    return branch.replace(/^release\//, "").replace(/-branch$/, "");
+  }
+
+  function renderSelector(versions) {
+    if (!Array.isArray(versions) || versions.length === 0) {
+      return;
+    }
+
+    const select = document.createElement("select");
+    select.className = "version-selector";
+    select.setAttribute("aria-label", "Documentation Version");
+
+    versions.forEach((branch) => {
+      const option = document.createElement("option");
+      // deployed folder name, used to build the URL
+      option.value = slug(branch);
+
+      // prettified display text
+      option.textContent = label(branch);
+
+      option.selected = slug(branch) === currentVersion;
+      select.appendChild(option);
+    });
+
+    select.addEventListener("change", () => {
+      // Jump to the same page in the chosen version.
+      // The custom 404 page handles the case where that page doesn't exist.
+      window.location.href = basePath + select.value + "/" + pageWithinVersion;
+    });
+
+    // Build a labeled "Version" section pinned to the bottom of the sidebar:
+    // "VERSION" label on the left, the dropdown on the right.
+    const sidebar = document.querySelector(".wy-nav-side");
+    if (sidebar) {
+      const section = document.createElement("div");
+      section.className = "version-section";
+
+      const labelEl = document.createElement("span");
+      labelEl.className = "version-label";
+      labelEl.textContent = "Version";
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "version-selector-wrapper";
+      wrapper.appendChild(select);
+
+      section.appendChild(labelEl);
+      section.appendChild(wrapper);
+      sidebar.appendChild(section);
+    }
+  }
+
+  // Run only after the DOM is parsed, so the docs-base-path meta tag exists
+  // even when this script is loaded earlier in <head> than the tag.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/templates/layout.html
+++ b/docs/templates/layout.html
@@ -26,6 +26,7 @@
   </div>
 {% endblock %}
 {% block extrahead %}
+  <meta name="docs-base-path" content="{{ docs_base_path }}">
   <meta name="color-scheme" content="dark light">
   {# Use dark mode loader script to prevent "flashing" of the page on load.
      As we need a <noscript> tag and very specific orderding of the tags, this can't be done via


### PR DESCRIPTION
Add version selector drowdown + add pycache to `.gitignore`.

The dropdown looks like this (bottom of nav bar):

<img width="150" alt="Screenshot 2026-07-29 at 12 46 05 PM" src="https://github.com/user-attachments/assets/297204fa-af76-4ef9-9d86-41f47b35caba" />

I'll manually generate the docs for v1.0 and v2.0 and push to gh-pages later so those pages can have the version dropdown as well.