### PR TITLE
docs: align light API signature style with dark theme

### DIFF
--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -196,7 +196,12 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
 }
 html.writer-html5 .rst-content dl:not(.docutils) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt {
     border-top: none;
-    background: var(--highlight-background-color);
+    /*
+     * API signature fill. Uses a soft, low-contrast tint so the signature
+     * reads as a flush card in both themes rather than a hard grey box in
+     * light. Falls back to the code-block background where unset.
+     */
+    background: var(--api-signature-background-color, var(--highlight-background-color));
 }
 html.writer-html5 .rst-content dl:not(.docutils) dl:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) dl:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt {
     border-left-color: var(--highlight-background-emph-color);
@@ -1434,8 +1439,8 @@ html.writer-html5 .rst-content dl.field-list>dd {
 }
 
 .document dl {
-    border-left: 1px solid rgba(35, 33, 55, 0.32);
-    border-bottom: 1px solid rgba(35, 33, 55, 0.32);
+    border-left: 1px solid var(--document-dl-border-color);
+    border-bottom: 1px solid var(--document-dl-border-color);
 
     & dt {
         padding: 8px 16px;

--- a/docs/static/css/dark.css
+++ b/docs/static/css/dark.css
@@ -76,6 +76,9 @@
     --highlight-background-color: var(--eclipse-blue);
     --highlight-border-color: var(--eclipse-blue);
     --highlight-background-emph-color: var(--eclipse-blue);
+    /* API signature fill: a subtle tint above the page (unchanged look). */
+    --api-signature-background-color: var(--eclipse-blue);
+    --document-dl-border-color: transparent;
     --highlight-default-color: var(--moon-silver);
     --highlight-comment-color: var(--lunar-dust);
     --highlight-keyword-color: var(--status-red);

--- a/docs/static/css/light.css
+++ b/docs/static/css/light.css
@@ -72,6 +72,13 @@
     --highlight-background-color: var(--moon-silver);
     --highlight-border-color: var(--moon-silver);
     --highlight-background-emph-color: var(--moon-silver);
+    /*
+     * API signature fill: a faint hubble-blue tint instead of the grey code
+     * background, so signatures read as a soft flush card on the near-white
+     * page, matching the borderless look of the dark theme.
+     */
+    --api-signature-background-color: rgba(87, 97, 255, 0.06);
+    --document-dl-border-color: transparent;
     --highlight-default-color: var(--meteor-grey);
     --highlight-comment-color: var(--meteor-grey);
     --highlight-keyword-color: var(--status-dark-red);


### PR DESCRIPTION
The API function signature block (dt.sig) has no border in either theme, but its background fill read very differently between them. Both themes drove the fill from --highlight-background-color, which in light is moon-silver — a mid-grey box on the near-white page that looked like a hard bordered card, while in dark (eclipse-blue on deep-space-blue) it sat nearly flush with the page.