### PR TITLE
fix: port/esp-idf: fix log not printing

### DIFF
--- a/port/esp-idf/hubble_esp_idf.c
+++ b/port/esp-idf/hubble_esp_idf.c
@@ -11,21 +11,39 @@
 
 int hubble_log(enum hubble_log_level level, const char *format, ...)
 {
-#if defined(CONFIG_LOG)
+#if (LOG_LOCAL_LEVEL > ESP_LOG_NONE)
 	static const char *_hubble_tag = "hubblenetwork";
-	va_list args;
-	static esp_log_level_t _log_level[HUBBLE_LOG_COUNT] = {
+	static const esp_log_level_t _log_level[HUBBLE_LOG_COUNT] = {
 		[HUBBLE_LOG_DEBUG] = ESP_LOG_DEBUG,
 		[HUBBLE_LOG_ERROR] = ESP_LOG_ERROR,
 		[HUBBLE_LOG_INFO] = ESP_LOG_INFO,
 		[HUBBLE_LOG_WARNING] = ESP_LOG_WARN,
 	};
 
+	/*
+	 * require_formatting: add the level name, timestamp, tag, etc.
+	 * This is Log V2 feature only, V1 just builds a plain string.
+	 */
+	esp_log_config_t config = {
+		.opts = {
+			.log_level = _log_level[level],
+			.constrained_env = false,
+			.require_formatting = true,
+			.dis_color = ESP_LOG_COLOR_DISABLED,
+			.dis_timestamp = ESP_LOG_TIMESTAMP_DISABLED,
+			.reserved = 0,
+		}};
+
+	va_list args;
+
 	va_start(args, format);
-	esp_log_va(ESP_LOG_CONFIG_INIT(_log_level[level]), _hubble_tag, format,
-		   args);
+	esp_log_va(config, _hubble_tag, format, args);
 	va_end(args);
-#endif /* defined(CONFIG_LOG) */
+
+#else
+	(void)level;
+	(void)format;
+#endif /* LOG_LOCAL_LEVEL > ESP_LOG_NONE */
 
 	return 0;
 }


### PR DESCRIPTION
CONFIG_LOG is a Zephyr macro. ESP-IDF uses ESP_LOG_, and there are 2 versions. V1 is the plain text, V2 is the one with format, log tag, etc. so changing the log port implementation to make sure logging works.