### PR TITLE
ci: bump actions to Node 24 majors

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -57,7 +57,7 @@ jobs:
           esac
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.setref.outputs.ref }}
           fetch-depth: 1
@@ -72,7 +72,7 @@ jobs:
           echo "Branch slug: ${SLUG}"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -103,7 +103,7 @@ jobs:
           make html
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: docs-${{ steps.slug.outputs.slug }}
           path: docs/_build/html
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - name: Download docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: docs-${{ needs.build.outputs.slug }}
           path: docs-output
@@ -142,7 +142,7 @@ jobs:
 
       # Check out gh-pages so we can update the versions file
       - name: Check out gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/build-samples-esp-idf.yaml
+++ b/.github/workflows/build-samples-esp-idf.yaml
@@ -28,7 +28,7 @@ jobs:
           - esp32s3
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload footprint artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: footprint-${{ matrix.espidf_target }}
           path: esp-idf-footprint-out/
@@ -96,10 +96,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all footprint artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: footprint-artifacts
           pattern: footprint-*

--- a/.github/workflows/build-samples-ti.yaml
+++ b/.github/workflows/build-samples-ti.yaml
@@ -25,7 +25,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Python dependencies
         run: pip install pyyaml

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -26,17 +26,17 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 
       - name: cache-pip
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/codecov.yaml') }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload footprint report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-${{ github.run_id }}
           path: twister-out/coverage.json

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -81,14 +81,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "recursive"
 
       # Also gives the SARIF filter step a pip-installable interpreter; the
       # system python3 on the runner is externally managed.
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -18,18 +18,18 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
 
     - name: cache-pip
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/compliance.yaml') }}

--- a/.github/workflows/ncs-tests.yaml
+++ b/.github/workflows/ncs-tests.yaml
@@ -57,7 +57,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.setref.outputs.ref }}
 
@@ -79,7 +79,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.find-image-tag.outputs.ref }}
           fetch-depth: 0

--- a/.github/workflows/reviewer.yaml
+++ b/.github/workflows/reviewer.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Detect changed areas
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             zephyr:
@@ -84,7 +84,7 @@ jobs:
           echo "reviewer=$reviewer" >> "$GITHUB_OUTPUT"
 
       - name: Assign PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const assignee = "${{ steps.pick.outputs.assignee }}"
@@ -99,7 +99,7 @@ jobs:
             });
 
       - name: Assign reviewers PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const author = context.payload.pull_request.user.login;

--- a/.github/workflows/zephyr-tests.yaml
+++ b/.github/workflows/zephyr-tests.yaml
@@ -57,13 +57,13 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.setref.outputs.ref }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload footprint report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: footprint-report-${{ github.run_id }}
           path: twister-out/twister_footprint.json


### PR DESCRIPTION
Node.js 20 is deprecated on GitHub Actions runners. Bump each affected first-party and third-party action to its minimal Node 24 major to clear the deprecation warning.