### PR TITLE
crypto: psa: Scattered fixes

### DIFF
--- a/src/crypto/psa.c
+++ b/src/crypto/psa.c
@@ -60,7 +60,7 @@ int hubble_crypto_cmac(const uint8_t key[CONFIG_HUBBLE_KEY_SIZE],
 	psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 	psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
 
-	psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_HASH);
+	psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_MESSAGE);
 	psa_set_key_type(&attributes, PSA_KEY_TYPE_AES);
 	psa_set_key_algorithm(&attributes, PSA_ALG_CMAC);
 	psa_set_key_bits(&attributes, HUBBLE_KEY_SIZE_BITS);

--- a/src/crypto/psa.c
+++ b/src/crypto/psa.c
@@ -78,13 +78,16 @@ int hubble_crypto_cmac(const uint8_t key[CONFIG_HUBBLE_KEY_SIZE],
 
 	status = psa_mac_update(&operation, input, input_len);
 	if (status != PSA_SUCCESS) {
-		psa_mac_abort(&operation);
 		goto mac_update_error;
 	}
 
 	status = psa_mac_sign_finish(&operation, output, HUBBLE_AES_BLOCK_SIZE,
 				     &mac_length);
 mac_update_error:
+	/* A failed update or sign_finish leaves the operation in an error
+	 * state that must be aborted; aborting a completed one is a no-op.
+	 */
+	(void)psa_mac_abort(&operation);
 mac_setup_error:
 	psa_destroy_key(key_id);
 

--- a/src/crypto/psa.c
+++ b/src/crypto/psa.c
@@ -89,7 +89,7 @@ mac_setup_error:
 	psa_destroy_key(key_id);
 
 import_key_error:
-	return status == PSA_SUCCESS ? 0 : -EINVAL;
+	return _psa_status_to_errno(status);
 }
 
 int hubble_crypto_aes_ctr(const uint8_t key[CONFIG_HUBBLE_KEY_SIZE],
@@ -139,7 +139,7 @@ cipher_iv_error:
 cipher_setup_error:
 	(void)psa_destroy_key(key_id);
 import_key_error:
-	return status == PSA_SUCCESS ? 0 : -EINVAL;
+	return _psa_status_to_errno(status);
 }
 
 void hubble_crypto_zeroize(void *buf, size_t len)


### PR DESCRIPTION
- Use proper flags in sign operation
- Propagate PSA errors
- Avoid left an operation in error state when sign finishes with error