### PR TITLE
pass_prediction: Set region pass experimental

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -292,7 +292,7 @@ TAB_SIZE               = 4
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                =
+ALIASES                = "experimental=@warning **Experimental API.** This interface may change or be removed in any release."
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -2446,7 +2446,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2454,7 +2454,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2487,7 +2487,8 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = __DOXYGEN__ \
+                         HUBBLE_EXPERIMENTAL=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/releases/3.0.rst
+++ b/docs/releases/3.0.rst
@@ -143,6 +143,7 @@ Satellite Network APIs:
 - :c:func:`hubble_sat_satellites_set` — configure orbital parameters
 - :c:func:`hubble_sat_next_pass_get` — predict the next pass over a point
 - :c:func:`hubble_sat_next_pass_region_get` — predict the next pass over a region
+  (**experimental**)
 - :c:func:`hubble_sat_min_elevation_angle_set` — set the minimum pass elevation
 - :c:func:`hubble_sat_dtm_packet_send`,
   :c:func:`hubble_sat_dtm_power_set`,

--- a/include/hubble/sat/pass_prediction.h
+++ b/include/hubble/sat/pass_prediction.h
@@ -154,6 +154,8 @@ int hubble_sat_next_pass_get(uint64_t t, const struct hubble_sat_device_pos *pos
  * rectangular geographic region defined by latitude and longitude
  * bounds, based on satellites orbital parameters.
  *
+ * @experimental
+ *
  * @param t Current time or the time to start the calculation (milliseconds since Unix epoch).
  * @param region Pointer to the geographic region definition.
  * @param pass The next satellite pass in case of success.

--- a/include/hubble/sat/pass_prediction.h
+++ b/include/hubble/sat/pass_prediction.h
@@ -16,6 +16,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <hubble/toolchain.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -157,6 +159,7 @@ int hubble_sat_next_pass_get(uint64_t t, const struct hubble_sat_device_pos *pos
  * @param pass The next satellite pass in case of success.
  * @return 0 on success or a negative value in case of error.
  */
+HUBBLE_EXPERIMENTAL
 int hubble_sat_next_pass_region_get(
 	uint64_t t, const struct hubble_sat_device_region *region,
 	struct hubble_sat_pass_info *pass);

--- a/include/hubble/toolchain.h
+++ b/include/hubble/toolchain.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Hubble Network, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file toolchain.h
+ * @brief Compiler-specific helpers used by the public Hubble headers.
+ **/
+
+#ifndef INCLUDE_HUBBLE_TOOLCHAIN_H
+#define INCLUDE_HUBBLE_TOOLCHAIN_H
+
+/**
+ * @def HUBBLE_EXPERIMENTAL
+ * @brief Marks a public API as experimental.
+ *
+ * An experimental API is functional but its signature, semantics or very
+ * existence may change or be removed in any release. It is not covered by the
+ * SDK's API stability guarantees. Where the toolchain supports it, calling one
+ * emits a compiler warning naming the function.
+ *
+ * Applied to the declaration in the header, never to the definition:
+ *
+ * @code
+ * HUBBLE_EXPERIMENTAL
+ * int hubble_some_api(void);
+ * @endcode
+ *
+ * Define @c HUBBLE_SILENCE_EXPERIMENTAL_WARNINGS before including any Hubble
+ * header to acknowledge the risk and silence the diagnostic globally. With GCC
+ * a single call site can be silenced instead:
+ *
+ * @code
+ * #pragma GCC diagnostic push
+ * #pragma GCC diagnostic ignored "-Wattribute-warning"
+ * ret = hubble_some_api();
+ * #pragma GCC diagnostic pop
+ * @endcode
+ */
+#define _HUBBLE_EXPERIMENTAL_MSG                                               \
+	"this Hubble API is experimental: it may change or be "                \
+	"removed in any release. Define HUBBLE_SILENCE_EXPERIMENTAL_WARNINGS " \
+	"to acknowledge and silence this warning."
+
+#if defined(HUBBLE_SILENCE_EXPERIMENTAL_WARNINGS) || defined(__DOXYGEN__)
+#define HUBBLE_EXPERIMENTAL
+#elif defined(__has_attribute)
+#if defined(__clang__) && __has_attribute(diagnose_if)
+#define HUBBLE_EXPERIMENTAL                                                    \
+	__attribute__((diagnose_if(1, _HUBBLE_EXPERIMENTAL_MSG, "warning")))
+#elif __has_attribute(warning)
+#define HUBBLE_EXPERIMENTAL __attribute__((warning(_HUBBLE_EXPERIMENTAL_MSG)))
+#else
+#define HUBBLE_EXPERIMENTAL
+#endif
+#else
+#define HUBBLE_EXPERIMENTAL
+#endif
+
+#endif /* INCLUDE_HUBBLE_TOOLCHAIN_H */

--- a/tests/zephyr/pass-prediction/CMakeLists.txt
+++ b/tests/zephyr/pass-prediction/CMakeLists.txt
@@ -6,3 +6,7 @@ project(ephemeris)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+# This test uses experimental API (marked HUBBLE_EXPERIMENTAL). Acknowledge
+# it so the test output stays clean.
+target_compile_definitions(app PRIVATE HUBBLE_SILENCE_EXPERIMENTAL_WARNINGS)


### PR DESCRIPTION
Add ways to mark an API is experimental in doxygen and in C code.

It generates build warning if an experimental API is used.