### PR TITLE
esp-idf: add SDK to ESP Component Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs/_doxygen/
 .cache/
 .ruff_cache/
 **/__pycache__/
+dist/
 
 # generated files
 **/key.c
@@ -23,3 +24,6 @@ docs/_doxygen/
 zephyr/blobs/nrf52
 zephyr/blobs/nrf53
 zephyr/blobs/nrf54
+
+# Virtual environments
+.venv/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Hubble Network, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if(ESP_PLATFORM)
+  include(${CMAKE_CURRENT_LIST_DIR}/port/esp-idf/hubblenetwork-sdk/CMakeLists.txt)
+endif()

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Hubble Network, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# As an ESP Component, in order for the Kconfig menu to show up in
+# idf.py menuconfig, the Kconfig file must present at the root
+if IDF_CMAKE
+rsource "port/esp-idf/hubblenetwork-sdk/Kconfig"
+endif

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,21 @@
+description: "On-device SDK for connecting to Hubble's Terrestrial (Bluetooth Low Energy) and Satellite Networks, built on a modular architecture that ports across RTOSes and hardware."
+tags:
+  - "Bluetooth"
+  - "BLE"
+  - "Satellite"
+files:
+  use_gitignore: true
+  exclude:
+    - ".git/**/*"
+    - ".github/**/*"
+    - ".venv/**/*"
+examples:
+  - path: "samples/esp-idf/"
+url: "https://hubble.com"
+repository: "https://github.com/HubbleNetwork/hubble-device-sdk.git"
+documentation: "https://hubblenetwork.github.io/hubble-device-sdk/main/"
+issues: "https://github.com/HubbleNetwork/hubble-device-sdk/issues"
+discussion: "https://github.com/HubbleNetwork/hubble-device-sdk/discussions"
+dependencies:
+  idf:
+    version: ">=6.0"

--- a/port/esp-idf/hubblenetwork-sdk/CMakeLists.txt
+++ b/port/esp-idf/hubblenetwork-sdk/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SDK_BASE_DIR ../../../)
+set(SDK_BASE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../..)
 
 set(SRCS
     "${SDK_BASE_DIR}/port/esp-idf/hubble_esp_idf.c"


### PR DESCRIPTION
Add necessary files to register the Hubble Network SDK as an ESP Component for the Component Registry. This includes a CMakeLists.txt, Kconfig, and idf_component.yml file.

I uploaded a test version on the staging server here https://components-staging.espressif.com/components/hongnguyen635/hubble-device-sdk/versions/3.0.0

I also downloaded the files and go through the flow to make sure that it works. Will add instruction on how to use and CI to auto upload on release later.