### PR TITLE
docs: Add Algolia site-verification meta tag

### DIFF
--- a/docs/templates/layout.html
+++ b/docs/templates/layout.html
@@ -28,6 +28,7 @@
 {% block extrahead %}
   <meta name="docs-base-path" content="{{ docs_base_path }}">
   <meta name="color-scheme" content="dark light">
+  <meta name="algolia-site-verification" content="5A89F681C1955ED8" />
   {# Use dark mode loader script to prevent "flashing" of the page on load.
      As we need a <noscript> tag and very specific orderding of the tags, this can't be done via
      the usual add_js_file()/add_css_file() Sphinx API.


### PR DESCRIPTION
Adds the algolia-site-verification meta tag to the base Sphinx template
so the Algolia Crawler can verify domain ownership for
hubblenetwork.github.io, enabling this site to be crawled into the
hubble-docs DocSearch index alongside the main Docusaurus docs.