### PR TITLE
zephyr: Kconfig: Declare SILABS_SISDK_RAIL_MULTIPROTOCOL

### DIFF
--- a/port/zephyr/Kconfig.silabs
+++ b/port/zephyr/Kconfig.silabs
@@ -1,6 +1,17 @@
 # Copyright (c) 2026 Hubble Network, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Zephyr declares SILABS_SISDK_RAIL_MULTIPROTOCOL in
+# modules/hal_silabs/simplicity_sdk/Kconfig, which only exists in trees that
+# carry the Simplicity SDK HAL glue. On older trees (for example the TI
+# simplelink-zephyr v3.7.0 fork) the configdefault below is the symbol's only
+# definition, so Kconfig reports it as typeless and the build aborts on the
+# warning. Declaring it here gives it a type everywhere; where the real
+# definition exists, Kconfig merges the two and its prompt and dependencies
+# still apply.
+config SILABS_SISDK_RAIL_MULTIPROTOCOL
+	bool
+
 if HUBBLE_SAT_NETWORK
 
 configdefault SOC_GECKO_CUSTOM_RADIO_PHY


### PR DESCRIPTION
Kconfig.silabs sets a configdefault on SILABS_SISDK_RAIL_MULTIPROTOCOL, which Zephyr declares in modules/hal_silabs/simplicity_sdk/Kconfig. That glue only exists in trees carrying the Simplicity SDK HAL, so on older trees the configdefault is the symbol's only definition. Kconfig then reports it as typeless and Zephyr turns that warning into an error, failing every build at CMake configure:

  warning: SILABS_SISDK_RAIL_MULTIPROTOCOL (defined at
    port/zephyr/Kconfig.silabs:11) defined without a type
  error: Aborting due to Kconfig warnings

This broke all TI board builds on the simplelink-zephyr v3.7.0 fork. SOC_GECKO_CUSTOM_RADIO_PHY is unaffected: soc/silabs/Kconfig declares it in both old and new trees.

Declare the symbol here so it always has a type. Where the real definition exists, Kconfig merges the two and its prompt and dependencies still apply; where it does not, the symbol is inert because nothing references it.

Verified with both the v3.7.0-ti and v4.4.0 kconfiglib against trees with and without the upstream declaration: the warning is gone in all four combinations and the resulting value is unchanged.