### PR TITLE
ci: add workflow to auto-publish ESP Component on a new tag

### DIFF
--- a/.github/workflows/publish-esp-component.yaml
+++ b/.github/workflows/publish-esp-component.yaml
@@ -1,0 +1,29 @@
+name: Upload ESP Component
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    permissions:
+      # required for OIDC Token
+      id-token: write
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+            submodules: 'recursive'
+      - name: Upload component to the component registry
+        uses: espressif/upload-components-ci-action@v2
+        with:
+          components: |
+            hubble-device-sdk: .
+          version: ${{ github.ref_name }}
+          namespace: "hubblenetwork"
+          # skip the rc tags
+          skip_pre_release: true


### PR DESCRIPTION
Add workflow to automatically publish to the ESP Component Registry when a new tag is created (but not for rc tags).