### PR TITLE
docs: esp-idf: add direction for using ESP Component Registry

### DIFF
--- a/docs/quickstart/esp-idf/index.rst
+++ b/docs/quickstart/esp-idf/index.rst
@@ -5,8 +5,9 @@ ESP-IDF
 
 This guide explains how to integrate the Hubble Device SDK into an
 `ESP-IDF <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html>`_
-project. The SDK ships as an ESP-IDF component that can be pulled into any
-ESP-IDF application via ``EXTRA_COMPONENT_DIRS``.
+project. The SDK ships as an ESP-IDF component, and can be added either from
+the `ESP Component Registry <https://components.espressif.com/components/hubblenetwork/hubble-device-sdk>`_
+or from a local copy of the repository.
 
 .. seealso::
 
@@ -23,13 +24,46 @@ Prerequisites
 - A supported ESP32 target. The BLE Network module works on any ESP32 chip
   with a Bluetooth® Low Energy controller supported by ESP-IDF. The Satellite
   Network module currently targets the **ESP32-C6**.
-- The Hubble Device SDK cloned or added to your project as a Git submodule.
 - Device ``key`` (generated when you register a new device to your organization
   through the Hubble Cloud API).
 
 
 Adding Hubble Network to an ESP-IDF Project
 *******************************************
+
+Option 1: ESP Component Registry (recommended)
+----------------------------------------------
+
+From the root of your project:
+
+.. code-block:: bash
+
+   # change '^3.0.0' to your desired version of the SDK in the Registry
+   idf.py add-dependency "hubblenetwork/hubble-device-sdk^3.0.0"
+
+This records the dependency in your project's ``idf_component.yml`` and
+downloads the SDK into ``managed_components/`` on the next build. ESP-IDF
+discovers components there automatically, so no ``EXTRA_COMPONENT_DIRS``
+entry is needed in your ``CMakeLists.txt``.
+
+To declare the dependency by hand instead of running ``add-dependency``, add it
+to ``main/idf_component.yml``:
+
+.. code-block:: yaml
+
+   dependencies:
+     hubblenetwork/hubble-device-sdk: ^3.0.0
+
+.. note::
+
+   If your project narrows the build with ``set(COMPONENTS ...)``, add the SDK's
+   directory name under ``managed_components/`` to that list as well because
+   anything omitted from ``set(COMPONENTS ...)`` is excluded from the build.
+
+Option 2: Local copy or Git submodule
+-------------------------------------
+
+Use this when building against an unreleased branch not listed in the Registry.
 
 #. Add the Hubble Device SDK to your application, for example as a submodule:
 
@@ -57,26 +91,30 @@ Adding Hubble Network to an ESP-IDF Project
 
       project(my-app LANGUAGES C)
 
-#. Enable the desired Hubble modules. Either run ``idf.py menuconfig`` and
-   toggle them under *Component config* → *Hubble*, or set them in your
-   project's ``sdkconfig.defaults``:
 
-   .. code-block:: kconfig
+Enabling Hubble Modules
+***********************
 
-      # Terrestrial (BLE) Network
-      CONFIG_HUBBLE_BLE_NETWORK=y
+This applies to both options above. Either run ``idf.py menuconfig`` and toggle
+the modules under *Component config* → *Hubble*, or set them in your project's
+``sdkconfig.defaults``:
 
-      # Satellite Network
-      CONFIG_HUBBLE_SAT_NETWORK=y
+.. code-block:: kconfig
 
-   When enabling the BLE Network module on ESP32 chips, you will also want the
-   standard BLE controller bits:
+   # Terrestrial (BLE) Network
+   CONFIG_HUBBLE_BLE_NETWORK=y
 
-   .. code-block:: kconfig
+   # Satellite Network
+   CONFIG_HUBBLE_SAT_NETWORK=y
 
-      CONFIG_BT_ENABLED=y
-      CONFIG_BT_BLE_50_FEATURES_SUPPORTED=n
-      CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y
+When enabling the BLE Network module on ESP32 chips, you will also want the
+standard BLE controller bits:
+
+.. code-block:: kconfig
+
+   CONFIG_BT_ENABLED=y
+   CONFIG_BT_BLE_50_FEATURES_SUPPORTED=n
+   CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y
 
 
 Satellite Network on ESP32-C6: Required PHY Blob


### PR DESCRIPTION
Add direction in quick start on how to add Hubble Device SDK as a component to an existing project.

The SDK is listed as a component in the ESP Registry!
https://components.espressif.com/components/hubblenetwork/hubble-device-sdk/versions/3.0.0
